### PR TITLE
remove ghost window when launched by "component" arg

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -69,7 +69,6 @@ class TrackerCommandProcessor(ClientCommandProcessor):
 
 
 class TrackerGameContext(CommonContext):
-    from kvui import GameManager
     game = ""
     httpServer_task: typing.Optional["asyncio.Task[None]"] = None
     tags = CommonContext.tags | {"Tracker"}
@@ -112,7 +111,7 @@ class TrackerGameContext(CommonContext):
     def set_events_callback(self, func: Optional[Callable[[list[str]], bool]] = None):
         self.events_callback = func
 
-    def build_gui(self, manager: GameManager):
+    def build_gui(self, manager: "kvui.GameManager"):
         from kivy.uix.boxlayout import BoxLayout
         from kivy.uix.tabbedpanel import TabbedPanelItem
         from kivy.uix.recycleview import RecycleView

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -111,7 +111,7 @@ class TrackerGameContext(CommonContext):
     def set_events_callback(self, func: Optional[Callable[[list[str]], bool]] = None):
         self.events_callback = func
 
-    def build_gui(self, manager: "kvui.GameManager"):
+    def build_gui(self, manager: "GameManager"):
         from kivy.uix.boxlayout import BoxLayout
         from kivy.uix.tabbedpanel import TabbedPanelItem
         from kivy.uix.recycleview import RecycleView

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -22,6 +22,9 @@ from MultiServer import mark_raw
 
 from Generate import main as GMain, mystery_argparse
 
+if typing.TYPE_CHECKING:
+    from kvui import GameManager
+
 # webserver imports
 import urllib.parse
 


### PR DESCRIPTION
## What is this fixing or adding?
importing kivy opens a ghost window, this should type the relevant methods without needing to do that import

## How was this tested?
opened Minit and UT through cli with component name, no ghost window

## If this makes graphical changes, please attach screenshots.
