### PR TITLE
Make UT possible to call ad hoc without using CommonClient to establish a connection

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -489,9 +489,10 @@ def updateTracker(ctx: TrackerGameContext):
             pass
     events = [location.item.name for location in state.events if location.player == ctx.player_id]
 
-    ctx.tracker_page.refresh_from_data()
+    if ctx.tracker_page:
+        ctx.tracker_page.refresh_from_data()
     ctx.locations_available = locations
-    if f"_read_hints_{ctx.team}_{ctx.slot}" in ctx.stored_data:
+    if ctx.ui and f"_read_hints_{ctx.team}_{ctx.slot}" in ctx.stored_data:
         ctx.ui.update_hints()
     if ctx.update_callback is not None:
         ctx.update_callback(callback_list)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -87,8 +87,14 @@ class TrackerGameContext(CommonContext):
     tracker_failed = False
     re_gen_passthrough = None
 
-    def __init__(self, server_address, password):
-        super().__init__(server_address, password)
+    def __init__(self, server_address, password, no_connection: bool = False):
+        if no_connection:
+            from worlds import network_data_package
+            self.item_names = self.NameLookupDict(self, "item")
+            self.location_names = self.NameLookupDict(self, "location")
+            self.update_data_package(network_data_package)
+        else:
+            super().__init__(server_address, password)
         self.items_handling = ITEMS_HANDLING
         self.locations_checked = []
         self.locations_available = []


### PR DESCRIPTION
## What is this fixing or adding?
makes it so that someone importing TrackerContext can create the context outside of an asyncio context if they don't want to use the connection part of commoncontext

## How was this tested?
```py
from worlds.tracker.TrackerClient import TrackerGameContext, updateTracker


def get_tracker_ctx(name):
    ctx = TrackerGameContext("", "", no_connection=True)
    ctx.run_generator()

    player_ids = [i for i, n in ctx.multiworld.player_name.items() if n == name]
    if len(player_ids) < 1:
        print("Player's Yaml not in tracker's list")
        return
    ctx.player_id = player_ids[0]  # should only really ever be one match
    return ctx


def get_in_logic(ctx, items=[], locations=[]):
    ctx.items_received = [(item,) for item in items]  # to account for the list being ids and not Items
    ctx.missing_locations = locations
    updateTracker(ctx)
    return ctx.locations_available


name = "qwintBug"
ctx = get_tracker_ctx(name)
print(get_in_logic(ctx, items=[16777224, 16777227, 16777289], locations=[16777360, 16777370, 16777410]))

# [16777370, 16777410]

```

## If this makes graphical changes, please attach screenshots.
