### PR TITLE
make sm progress dots not crash frozen

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -28,6 +28,9 @@ if typing.TYPE_CHECKING:
 # webserver imports
 import urllib.parse
 
+if not sys.stdout:  # to make sure sm varia's "i'm working" dots don't break UT in frozen
+    sys.stdout = open(os.devnull, 'w')  # from https://stackoverflow.com/a/6735958
+
 logger = logging.getLogger("Client")
 
 DEBUG = False


### PR DESCRIPTION
## What is this fixing or adding?
makes it so that when sm varia calls stdout to print dots every time it retries it doesn't crash on frozen installs (where it doesn't exist)

## How was this tested?
threw a stdout in the code, saw frozen crash on non-debug, saw the prints when a console was open, and after the fix saw the same prints except frozen didn't crash

## If this makes graphical changes, please attach screenshots.
