### PR TITLE
use make_gui so that others reusing tracker so under 3297 there is no…

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -334,23 +334,22 @@ class TrackerGameContext(CommonContext):
 
         HintLog.refresh_hints = update_available_hints
 
-    def run_gui(self):
+    def make_gui(self):
         from kvui import GameManager
         from kivy.properties import StringProperty, NumericProperty, BooleanProperty
         try:
             from kvui import ImageLoader #one of these needs to be loaded
         except ImportError:
             from .TrackerKivy import ImageLoader #use local until ap#3629 gets merged/released
-        
 
         class TrackerManager(GameManager):
             source = StringProperty("")
             loc_size = NumericProperty(20)
             loc_border = NumericProperty(5)
             enable_map = BooleanProperty(False)
-            logging_pairs = [
-                ("Client", "Archipelago")
-            ]
+            # logging_pairs = [
+            #     ("Client", "Archipelago")
+            # ]
             base_title = "Archipelago Tracker Client"
 
             def build(self):
@@ -362,8 +361,12 @@ class TrackerGameContext(CommonContext):
 
                 return container
 
-        self.ui = TrackerManager(self)
         self.load_kv()
+        return TrackerManager(self)
+
+    def run_gui(self):
+        # TODO remove and break back compat eventually
+        self.ui = self.make_gui()
         self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
         return self
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -335,21 +335,18 @@ class TrackerGameContext(CommonContext):
         HintLog.refresh_hints = update_available_hints
 
     def make_gui(self):
-        from kvui import GameManager
+        ui = super().make_gui(self)  # before the kivy imports so kvui gets loaded first
         from kivy.properties import StringProperty, NumericProperty, BooleanProperty
         try:
             from kvui import ImageLoader #one of these needs to be loaded
         except ImportError:
             from .TrackerKivy import ImageLoader #use local until ap#3629 gets merged/released
 
-        class TrackerManager(GameManager):
+        class TrackerManager(ui):
             source = StringProperty("")
             loc_size = NumericProperty(20)
             loc_border = NumericProperty(5)
             enable_map = BooleanProperty(False)
-            # logging_pairs = [
-            #     ("Client", "Archipelago")
-            # ]
             base_title = "Archipelago Tracker Client"
 
             def build(self):
@@ -362,13 +359,7 @@ class TrackerGameContext(CommonContext):
                 return container
 
         self.load_kv()
-        return TrackerManager(self)
-
-    def run_gui(self):
-        # TODO remove and break back compat eventually
-        self.ui = self.make_gui()
-        self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
-        return self
+        return TrackerManager
 
     def load_kv(self):
         from kivy.lang import Builder


### PR DESCRIPTION
## What is this fixing or adding?
uses the new api in [PR 3297](https://github.com/ArchipelagoMW/Archipelago/pull/3297), this also means a decent chunk of the kivy code can probably be cleaned up, but wanted to do minimal impact changes to show that downstream clients can ignorantly apply tracker's make_gui

## How was this tested?
on 3297 the following worked to use tracker if loaded and base if not
```py
ui = super().make_gui()
ui.base_title = "Minit Client"
return ui
```
:)

also retested with some smarter back-compat versions on 3297 and on main

## If this makes graphical changes, please attach screenshots.
