### PR TITLE
uses a proper Group for host.yaml settings including docstrings!

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -442,7 +442,7 @@ class TrackerGameContext(CommonContext):
         await super().disconnect(allow_autoreconnect)
 
     def _set_host_settings(self, host):
-        tracker_settings = host['universal_tracker']
+        tracker_settings = host.universal_tracker
         report_type = "Both"
         if tracker_settings['include_location_name']:
             if tracker_settings['include_region_name']:

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -442,26 +442,16 @@ class TrackerGameContext(CommonContext):
         await super().disconnect(allow_autoreconnect)
 
     def _set_host_settings(self, host):
-        if 'universal_tracker' not in host:
-            host['universal_tracker'] = {}
-        if 'player_files_path' not in host['universal_tracker']:
-            host['universal_tracker']['player_files_path'] = None
-        if 'include_region_name' not in host['universal_tracker']:
-            host['universal_tracker']['include_region_name'] = False
-        if 'include_location_name' not in host['universal_tracker']:
-            host['universal_tracker']['include_location_name'] = True
-        if 'hide_excluded_locations' not in host['universal_tracker']:
-            host['universal_tracker']['hide_excluded_locations'] = False
+        tracker_settings = host['universal_tracker']
         report_type = "Both"
-        if host['universal_tracker']['include_location_name']:
-            if host['universal_tracker']['include_region_name']:
+        if tracker_settings['include_location_name']:
+            if tracker_settings['include_region_name']:
                 report_type = "Both"
             else:
                 report_type = "Location"
         else:
             report_type = "Region"
-        host.save()
-        return host['universal_tracker']['player_files_path'], report_type, host['universal_tracker'][
+        return tracker_settings['player_files_path'], report_type, tracker_settings[
             'hide_excluded_locations']
 
     def run_generator(self, slot_data: Optional[Dict] = None):

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -1,7 +1,7 @@
 
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
-from typing import Dict, Optional, List, Any, Union
-
+from typing import Dict, Optional, List, Any, Union, ClassVar
+from settings import Group, Bool, LocalFolderPath, _world_settings_name_cache
 
 def launch_client():
     import sys
@@ -11,8 +11,35 @@ def launch_client():
     else:
         TCMain()
 
+
+class TrackerSettings(Group):
+    class TrackerPlayersPath(LocalFolderPath):
+        """Alternative Players folder for UT to use"""
+
+    class RegionNameBool(Bool):
+        """Show Region names in the UT tab"""
+
+    class LocationNameBool(Bool):
+        """Show Location names in the UT tab"""
+
+    class HideExcluded(Bool):
+        """Have the UT tab ignore excluded locations"""
+
+    player_files_path: TrackerPlayersPath = TrackerPlayersPath("Players")
+    include_region_name: Union[RegionNameBool, bool] = False
+    include_location_name: Union[LocationNameBool, bool] = True
+    hide_excluded_locations: Union[HideExcluded, bool] = False
+
+
 class TrackerWorld:
+    settings: ClassVar[TrackerSettings]
+    settings_key = "universal_tracker"
     pass
+
+
+# TODO: ask if there's an easier way to not register a world but register settings
+_world_settings_name_cache["universal_tracker"] = f"{TrackerWorld.__module__}.{TrackerWorld.__name__}"
+# Settings.universal_tracker = TrackerSettings()
 
 class UTMapTabData:
     """The holding class for all the poptracker integration values"""

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -15,7 +15,7 @@ def launch_client():
 
 class TrackerSettings(Group):
     class TrackerPlayersPath(LocalFolderPath):
-        """Alternative Players folder for UT to use"""
+        """Players folder for UT look for YAMLs"""
 
     class RegionNameBool(Bool):
         """Show Region names in the UT tab"""

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -37,9 +37,9 @@ class TrackerWorld:
     pass
 
 
-# TODO: ask if there's an easier way to not register a world but register settings
+# TODO: use the proper API for registering settings without a World class once it exists,,
 _world_settings_name_cache["universal_tracker"] = f"{TrackerWorld.__module__}.{TrackerWorld.__name__}"
-# Settings.universal_tracker = TrackerSettings()
+
 
 class UTMapTabData:
     """The holding class for all the poptracker integration values"""

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -2,6 +2,7 @@
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
 from typing import Dict, Optional, List, Any, Union, ClassVar
 from settings import Group, Bool, LocalFolderPath, _world_settings_name_cache
+from worlds.AutoWorld import World
 
 def launch_client():
     import sys
@@ -31,14 +32,15 @@ class TrackerSettings(Group):
     hide_excluded_locations: Union[HideExcluded, bool] = False
 
 
-class TrackerWorld:
+class TrackerWorld(World):
     settings: ClassVar[TrackerSettings]
     settings_key = "universal_tracker"
-    pass
 
-
-# TODO: use the proper API for registering settings without a World class once it exists,,
-_world_settings_name_cache["universal_tracker"] = f"{TrackerWorld.__module__}.{TrackerWorld.__name__}"
+    # to make auto world register happy so we can register our settings
+    game = "Universal Tracker"
+    hidden = True
+    item_name_to_id = {}
+    location_name_to_id = {}
 
 
 class UTMapTabData:


### PR DESCRIPTION
## What is this fixing or adding?
uses a proper Group for host.yaml settings including docstrings!

Note: jury's out on how to hook the UT settings Group into Settings properly so that part of init may need updating

## How was this tested?
opened UT with a broken kdl3 apworld in custom_worlds (note: the lib/worlds version needs to be an .apworld too),
confirmed that without a host.yaml, without ut settings, and with non-default ut settings, all generate and track fine but don't save to host.yaml until the issue apworld gets removed/fixed

## If this makes graphical changes, please attach screenshots.
