### PR TITLE
Added /next_progression command, which tells the player what items can be sent that will immediately unlock new locations.

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -150,6 +150,23 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         self.ctx.ignored_locations.clear()
         updateTracker(self.ctx)
         logger.info("Reset ignored locations.")
+    def _cmd_next_progression(self):
+        """Finds all items that will unlock a check immediately when collected, and how many new checks they will unlock."""
+        prev_manual_items = self.ctx.manual_items
+        self.ctx.manual_items = []
+        updateTracker(self.ctx)
+        baseLocs = self.ctx.locations_available
+        counter = Counter()
+        for item in self.ctx.multiworld.get_items():
+            if item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing:
+                self.ctx.manual_items.append(item.name)
+                updateTracker(self.ctx)
+                newlocs = set(self.ctx.locations_available) - set(baseLocs)
+                if len(newlocs) != 0:
+                    counter[item.name] = len(newlocs)
+                self.ctx.manual_items = []
+        logger.info(counter)
+        self.ctx.manual_items = prev_manual_items
 
 
 class TrackerGameContext(CommonContext):

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -153,8 +153,6 @@ class TrackerCommandProcessor(ClientCommandProcessor):
     def _cmd_next_progression(self):
         """Finds all items that will unlock a check immediately when collected, and how many new checks they will unlock."""
         prev_manual_items = self.ctx.manual_items
-        self.ctx.manual_items = []
-        updateTracker(self.ctx)
         baseLocs = self.ctx.locations_available
         counter = Counter()
         for item in self.ctx.multiworld.get_items():
@@ -164,7 +162,7 @@ class TrackerCommandProcessor(ClientCommandProcessor):
                 newlocs = set(self.ctx.locations_available) - set(baseLocs)
                 if len(newlocs) != 0:
                     counter[item.name] = len(newlocs)
-                self.ctx.manual_items = []
+                self.ctx.manual_items = prev_manual_items
         logger.info(counter)
         self.ctx.manual_items = prev_manual_items
         updateTracker(self.ctx)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -151,17 +151,17 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         updateTracker(self.ctx)
         logger.info("Reset ignored locations.")
     def _cmd_next_progression(self):
-        """Finds all items that will unlock a check immediately when collected, and how many new checks they will unlock."""
+        """Finds all items that will unlock a check immediately when collected, and a best guess of how many new checks they will unlock."""
         prev_manual_items = self.ctx.manual_items.copy()
         updateTracker(self.ctx)
         baseLocs = self.ctx.locations_available
         counter = Counter()
         for item in self.ctx.multiworld.get_items():
-            if item.game == self.ctx.game and (item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing):
+            if item.game == self.ctx.game and ItemClassification.progression in item.classification:
                 self.ctx.manual_items.append(item.name)
                 updateTracker(self.ctx)
                 newlocs = set(self.ctx.locations_available) - set(baseLocs)
-                if len(newlocs) != 0:
+                if newlocs:
                     counter[item.name] = len(newlocs)
                 self.ctx.manual_items = prev_manual_items.copy()
         

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -164,7 +164,9 @@ class TrackerCommandProcessor(ClientCommandProcessor):
                 if len(newlocs) != 0:
                     counter[item.name] = len(newlocs)
                 self.ctx.manual_items = prev_manual_items.copy()
-        logger.info(counter)
+        
+        for (item, count) in counter.most_common():
+            logger.info(f"{item} unlocks {count} checks.")
         self.ctx.manual_items = prev_manual_items
         updateTracker(self.ctx)
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -163,7 +163,8 @@ class TrackerCommandProcessor(ClientCommandProcessor):
             if newlocs:
                 counter[item] = newlocs
             self.ctx.manual_items.pop()
-        
+        if not counter:
+            logger.info("No item will unlock any checks right now.")
         for (item, count) in counter.most_common():
             logger.info(f"{item} unlocks {count} checks.")
         updateTracker(self.ctx)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -152,22 +152,20 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         logger.info("Reset ignored locations.")
     def _cmd_next_progression(self):
         """Finds all items that will unlock a check immediately when collected, and a best guess of how many new checks they will unlock."""
-        prev_manual_items = self.ctx.manual_items.copy()
         updateTracker(self.ctx)
-        baseLocs = self.ctx.locations_available
+        baseLocs = len(self.ctx.locations_available)
         counter = Counter()
-        for item in self.ctx.multiworld.get_items():
-            if item.game == self.ctx.game and ItemClassification.progression in item.classification:
-                self.ctx.manual_items.append(item.name)
-                updateTracker(self.ctx)
-                newlocs = set(self.ctx.locations_available) - set(baseLocs)
-                if newlocs:
-                    counter[item.name] = len(newlocs)
-                self.ctx.manual_items = prev_manual_items.copy()
+        items_to_check = {item.name for item in self.ctx.multiworld.get_items() if item.game == self.ctx.game and ItemClassification.progression in item.classification} 
+        for item in items_to_check:
+            self.ctx.manual_items.append(item)
+            updateTracker(self.ctx)
+            newlocs = len(self.ctx.locations_available) - baseLocs
+            if newlocs:
+                counter[item] = newlocs
+            self.ctx.manual_items.pop()
         
         for (item, count) in counter.most_common():
             logger.info(f"{item} unlocks {count} checks.")
-        self.ctx.manual_items = prev_manual_items
         updateTracker(self.ctx)
 
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -152,17 +152,18 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         logger.info("Reset ignored locations.")
     def _cmd_next_progression(self):
         """Finds all items that will unlock a check immediately when collected, and how many new checks they will unlock."""
-        prev_manual_items = self.ctx.manual_items
+        prev_manual_items = self.ctx.manual_items.copy()
+        updateTracker(self.ctx)
         baseLocs = self.ctx.locations_available
         counter = Counter()
         for item in self.ctx.multiworld.get_items():
-            if item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing:
+            if item.game == self.ctx.game and (item.classification == ItemClassification.progression or item.classification == ItemClassification.progression_skip_balancing):
                 self.ctx.manual_items.append(item.name)
                 updateTracker(self.ctx)
                 newlocs = set(self.ctx.locations_available) - set(baseLocs)
                 if len(newlocs) != 0:
                     counter[item.name] = len(newlocs)
-                self.ctx.manual_items = prev_manual_items
+                self.ctx.manual_items = prev_manual_items.copy()
         logger.info(counter)
         self.ctx.manual_items = prev_manual_items
         updateTracker(self.ctx)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -167,6 +167,7 @@ class TrackerCommandProcessor(ClientCommandProcessor):
                 self.ctx.manual_items = []
         logger.info(counter)
         self.ctx.manual_items = prev_manual_items
+        updateTracker(self.ctx)
 
 
 class TrackerGameContext(CommonContext):

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -155,7 +155,7 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         updateTracker(self.ctx)
         baseLocs = len(self.ctx.locations_available)
         counter = Counter()
-        items_to_check = {item.name for item in self.ctx.multiworld.get_items() if item.game == self.ctx.game and ItemClassification.progression in item.classification} 
+        items_to_check = {item.name for item in self.ctx.multiworld.get_items() if item.player == self.ctx.player_id and item.advancement}
         for item in items_to_check:
             self.ctx.manual_items.append(item)
             updateTracker(self.ctx)
@@ -166,7 +166,7 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         if not counter:
             logger.info("No item will unlock any checks right now.")
         for (item, count) in counter.most_common():
-            logger.info(f"{item} unlocks {count} checks.")
+            logger.info(f"{item} unlocks {count} check{'s' if count > 1 else ''}.")
         updateTracker(self.ctx)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds a /next_progression command, which displays what items can be received that will help immediately, and displays how many locations they will unlock.

## How was this tested?
Locally, through several worlds, and using both !getitem and /manually_collect, as they both work now, and everything seems to be in order.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/a513cfe9-d368-4a33-8009-72fa4b567586)

(apparently a unit test fails but that must just be a random failure from upstream overcooked 2)