### PR TITLE
trust empty yamls even if launch multi fails or has a same named yaml

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -641,6 +641,7 @@ class TrackerGameContext(CommonContext):
                     slot: game if game not in REGEN_WORLDS else "Archipelago"
                     for slot, game in g_args.game.items()
                     }
+                # TODO empty out generic options for slots we moved to "Archipelago"
                 self.launch_multiworld = self.TMain(g_args, seed)
                 self.multiworld = self.launch_multiworld
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -794,7 +794,7 @@ def load_json(pack, path):
 def updateTracker(ctx: TrackerGameContext) -> CurrentTrackerState:
     if ctx.player_id is None or ctx.multiworld is None:
         logger.error("Player YAML not installed or Generator failed")
-        ctx.set_page("Check Player YAMLs for error")
+        ctx.set_page(f"Check Player YAMLs for error; Tracker {UT_VERSION} for AP version {__version__}")
         return
 
     state = CollectionState(ctx.multiworld)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -172,7 +172,6 @@ class TrackerGameContext(CommonContext):
     gen_error = None
     output_format = "Both"
     hide_excluded = False
-    tracker_failed = False
     re_gen_passthrough = None
     cached_multiworlds: List[MultiWorld] = []
     cached_slot_data: List[Dict[str, Any]] = []
@@ -257,6 +256,10 @@ class TrackerGameContext(CommonContext):
     def clear_page(self):
         if self.tracker_page is not None:
             self.tracker_page.resetData()
+
+    def set_page(self, line: str):
+        if self.tracker_page is not None:
+            self.tracker_page.data = [{"text": line}]
 
     def log_to_tab(self, line: str, sort: bool = False):
         if self.tracker_page is not None:
@@ -565,6 +568,7 @@ class TrackerGameContext(CommonContext):
             self.manual_items.clear()
             self.ignored_locations.clear()
             self.location_alias_map = {}
+            self.set_page("Connect to a slot to start tracking!")
 
         await super().disconnect(allow_autoreconnect)
 
@@ -787,12 +791,9 @@ def load_json(pack, path):
     return json.loads(pkgutil.get_data(pack, path).decode('utf-8-sig'))
 
 def updateTracker(ctx: TrackerGameContext) -> CurrentTrackerState:
-    if ctx.tracker_failed:
-        return #just return and don't bug the player
     if ctx.player_id is None or ctx.multiworld is None:
         logger.error("Player YAML not installed or Generator failed")
-        ctx.log_to_tab("Check Player YAMLs for error", False)
-        ctx.tracker_failed = True
+        ctx.set_page("Check Player YAMLs for error")
         return
 
     state = CollectionState(ctx.multiworld)


### PR DESCRIPTION
## What is this fixing or adding?
do a little code shuffle

## How was this tested?
opened a astalon slot with the correct yaml in players, with that yaml gone, with a v6 yaml named the same, and with all yamls gone

## If this makes graphical changes, please attach screenshots.
