### PR TITLE
checksum mismatch warning

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -487,6 +487,8 @@ class TrackerGameContext(CommonContext):
                 if getattr(connected_cls, "disable_ut", False):
                     self.log_to_tab("World Author has requested UT be disabled on this world, please respect their decision")
                     return
+                if self.checksums[self.game] != connected_cls.get_data_package_data()["checksum"]:
+                    logger.warning("*****\nWarning: the local datapackage for the connected game does not match the server's datapackage\n*****")
                 # first check if we don't need a yaml
                 if getattr(connected_cls, "ut_can_gen_without_yaml", False):
                     with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION

## What is this fixing or adding?
adds a warning on connect if the server and local checksums are different

will break 0.5.1 back compat

## How was this tested?
![image](https://github.com/user-attachments/assets/a1c93d23-5fde-4bc2-84f1-deddf448f9ea)


## If this makes graphical changes, please attach screenshots.
