### PR TITLE
Add document for describing APWorld integration

### DIFF
--- a/worlds/tracker/docs/apworld-integration.md
+++ b/worlds/tracker/docs/apworld-integration.md
@@ -2,6 +2,8 @@
 
 This document describes the changes you need to make to fully integrate your APWorld with Universal Tracker. It assumes you are already familiar with the basics of how UT works. If you haven't already, read through the [re-gen-passthrough](re-gen-passthrough.md) document.
 
+The examples listed in this document are high-level. For reference implementations for these different features take a look at the [UT Integration Library](https://discord.com/channels/731205301247803413/1367996449270530080/1367997223991902219) thread in the AP discord.
+
 ## Providing information during generation
 
 UT does not have access to the seed used during the original generation. This means that any randomization that is not a direct result of YAML options or AP items will not be the same when UT runs and must be provided in slot data. This can include entrance rando (GER or otherwise), level order, starting location, or any similar options that don't use items directly.
@@ -12,56 +14,75 @@ Best practice is to store these random results on your world instance and pass t
     def fill_slot_data(self) -> dict[str, Any]:
         return {
             "starting_location": self.starting_location,
-            "entrances": self.randomized_entrances,
-            # etc
+            "entrances": self.randomized_entrances, # eg the result of calling randomize_entrances(...).pairings
+            # Add any as needed
         }
 ```
 
 ## Loading provided information
 
+You can access the slot data from the original generation by defining an `interpret_slot_data` function in your world. UT will call this function once connected to the multiworld with the slot data it recieved for that slot. Using this data, you can adjust any world state that affects your rules, such as world instance attributes or entrance connections.
+
 ```python
     def interpret_slot_data(self, slot_data: dict[str, Any]) -> None:
         if "starting_location" in slot_data:
-            self.starting_location = slot_data["starting_location"]
+            self.origin_region_name = slot_data["starting_location"]
+
         if "entrances" in slot_data:
-            for entrance in slot_data["entrances"]:
-                # you may need to adjust region connections for
+            # Update entrance connections for ER
+            entrances = {
+                entrance.name: entrance
+                for region in self.get_regions()
+                for entrance in region.entrances
+            }
+            for source_exit, target_entrance in slot_data["entrances"]:
+                entrances[source_exit].connected_region = entrances[target_entrance].parent_region
 ```
+
+You may also want to adjust your world's behaviour in other functions to reduce the amount of work you need to do in `interpret_slot_data`. To do so, you can check the `generation_is_fake` attribute on the `multiworld` object, which will be `True` if your world is generating inside UT. You can use this to skip doing things that will be handled by `interpret_slot_data` later, or to run code that would normally be skipped based on options. For example, you can create every possible location and let UT filter them out to just what exists from the server so you don't need to worry about creating them later.
 
 ```python
     def create_regions(self) -> None:
-        is_ut = getattr(self, "generation_is_fake", False)
-        if self.option.randomize_things.value or is_ut:
+        is_ut = getattr(self.multiworld, "generation_is_fake", False)
+        if self.randomly_rolled_property == 1 or is_ut:
+            # This location will always be created by UT regardless of options
             self.create_location(...)
 ```
 
 ## Generating without a YAML
 
+You can also make it so a YAML is not required to generate for your world. To do so, you must first store all options that affect generation in your slot data.
+
 ```python
     def fill_slot_data(self) -> dict[str, Any]:
+        # Store all defined options
         option_fields = [field.name for field in dataclasses.fields(self.options)]
-        # to exclude default options you can add:
-        # if field not in dataclasses.fields(PerGameCommonOptions)
         return {
-            # randomized results as above
+            # Keep other randomized results as above
             "options": self.options.as_dict(*option_fields),
         }
 ```
 
+To make implementation simpler, instead of the large amount of adjustments you'd likely have to make in `interpret_slot_data`, you can instead turn it into a static method that simply returns the slot data. This will inform UT that instead of doing an initial generation when it opens, it will do a regen once connected to the multiworld.
+
 ```python
     @staticmethod
     def interpret_slot_data(slot_data: dict[str, Any]) -> dict[str, Any]:
-        # Trigger a 2nd generation in UT
+        # Trigger a regen in UT
         return slot_data
 ```
+
+During the regen, you can access the slot data via `re_gen_passthrough` on the multiworld object. Early in gen you can inspect this object to set any instance attributes or options needed from the slot data so your later functions will behave as expected.
 
 ```python
     def generate_early(self) -> None:
         re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})
         if re_gen_passthrough and self.game in re_gen_passthrough:
+            # Get the passed through slot data from the real generation
             slot_data: dict[str, Any] = re_gen_passthrough[self.game]
 
             slot_options: dict[str, Any] = slot_data.get("options", {})
+            # Set all your options here instead of getting them from the yaml
             for key, value in slot_options.items():
                 opt: Optional[Option] = getattr(self.options, key, None)
                 if opt is not None:

--- a/worlds/tracker/docs/apworld-integration.md
+++ b/worlds/tracker/docs/apworld-integration.md
@@ -1,0 +1,77 @@
+# APWorld integration
+
+This document describes the changes you need to make to fully integrate your APWorld with Universal Tracker. It assumes you are already familiar with the basics of how UT works. If you haven't already, read through the [re-gen-passthrough](re-gen-passthrough.md) document.
+
+## Providing information during generation
+
+UT does not have access to the seed used during the original generation. This means that any randomization that is not a direct result of YAML options or AP items will not be the same when UT runs and must be provided in slot data. This can include entrance rando (GER or otherwise), level order, starting location, or any similar options that don't use items directly.
+
+Best practice is to store these random results on your world instance and pass them into the result of `fill_slot_data`.
+
+```python
+    def fill_slot_data(self) -> dict[str, Any]:
+        return {
+            "starting_location": self.starting_location,
+            "entrances": self.randomized_entrances,
+            # etc
+        }
+```
+
+## Loading provided information
+
+```python
+    def interpret_slot_data(self, slot_data: dict[str, Any]) -> None:
+        if "starting_location" in slot_data:
+            self.starting_location = slot_data["starting_location"]
+        if "entrances" in slot_data:
+            for entrance in slot_data["entrances"]:
+                # you may need to adjust region connections for
+```
+
+```python
+    def create_regions(self) -> None:
+        is_ut = getattr(self, "generation_is_fake", False)
+        if self.option.randomize_things.value or is_ut:
+            self.create_location(...)
+```
+
+## Generating without a YAML
+
+```python
+    def fill_slot_data(self) -> dict[str, Any]:
+        option_fields = [field.name for field in dataclasses.fields(self.options)]
+        # to exclude default options you can add:
+        # if field not in dataclasses.fields(PerGameCommonOptions)
+        return {
+            # randomized results as above
+            "options": self.options.as_dict(*option_fields),
+        }
+```
+
+```python
+    @staticmethod
+    def interpret_slot_data(slot_data: dict[str, Any]) -> dict[str, Any]:
+        # Trigger a 2nd generation in UT
+        return slot_data
+```
+
+```python
+    def generate_early(self) -> None:
+        re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})
+        if re_gen_passthrough and self.game in re_gen_passthrough:
+            slot_data: dict[str, Any] = re_gen_passthrough[self.game]
+
+            slot_options: dict[str, Any] = slot_data.get("options", {})
+            for key, value in slot_options.items():
+                opt: Optional[Option] = getattr(self.options, key, None)
+                if opt is not None:
+                    # You can also set .value directly but that won't work if you have OptionSets
+                    setattr(self.options, key, opt.from_any(value))
+```
+
+The last thing to do is inform UT that your world can generate without a YAML.
+
+```python
+class MyWorld(World):
+    ut_can_gen_without_yaml = True
+```

--- a/worlds/tracker/docs/apworld-integration.md
+++ b/worlds/tracker/docs/apworld-integration.md
@@ -1,14 +1,14 @@
 # APWorld integration
 
-This document describes the changes you need to make to fully integrate your APWorld with Universal Tracker. It assumes you are already familiar with the basics of how UT works. If you haven't already, read through the [re-gen-passthrough](re-gen-passthrough.md) document.
+This document describes the changes you need to make to fully integrate your APWorld with Universal Tracker (UT). It assumes you are already familiar with the basics of how UT works. If you haven't already, read through the [re-gen-passthrough](re-gen-passthrough.md) document.
 
 The examples listed in this document are high-level. For reference implementations for these different features take a look at the [UT Integration Library](https://discord.com/channels/731205301247803413/1367996449270530080/1367997223991902219) thread in the AP discord.
 
 ## Providing information during generation
 
-UT does not have access to the seed used during the original generation. This means that any randomization that is not a direct result of YAML options or AP items will not be the same when UT runs and must be provided in slot data. This can include entrance rando (GER or otherwise), level order, starting location, or any similar options that don't use items directly.
+UT does not have access to the seed used during the original generation. This means that any randomization that is not a direct result of YAML options or AP items will not be the same when UT runs and must be provided in slot data. This can include entrance rando, level order, starting location, or similar options that don't use items directly.
 
-Best practice is to store these random results on your world instance and pass them into the result of `fill_slot_data`.
+Best practice is to pass these randomized results into `fill_slot_data`.
 
 ```python
     def fill_slot_data(self) -> dict[str, Any]:
@@ -21,7 +21,7 @@ Best practice is to store these random results on your world instance and pass t
 
 ## Loading provided information
 
-You can access the slot data from the original generation by defining an `interpret_slot_data` function in your world. UT will call this function once connected to the multiworld with the slot data it recieved for that slot. Using this data, you can adjust any world state that affects your rules, such as world instance attributes or entrance connections.
+You can access the slot data from the original generation by defining an `interpret_slot_data` function in your world. UT will call this function once connected to the multiworld with the slot data it received from that slot. Using this data, you can adjust any world state that affects your rules, such as world instance attributes or entrance connections.
 
 ```python
     def interpret_slot_data(self, slot_data: dict[str, Any]) -> None:
@@ -51,15 +51,13 @@ You may also want to adjust your world's behaviour in other functions to reduce 
 
 ## Generating without a YAML
 
-You can also make it so a YAML is not required to generate for your world. To do so, you must first store all options that affect generation in your slot data.
+You can also make it so a YAML is not required to generate for your world. To do so, you must first store all options that affect generation in your slot data. Take care not to include options that don't affect generation and aren't useful for the game client.
 
 ```python
     def fill_slot_data(self) -> dict[str, Any]:
-        # Store all defined options
-        option_fields = [field.name for field in dataclasses.fields(self.options)]
         return {
             # Keep other randomized results as above
-            "options": self.options.as_dict(*option_fields),
+            "options": self.options.as_dict("randomize_things", "randomize_stuff", "logic_difficulty"),
         }
 ```
 
@@ -90,7 +88,7 @@ During the regeneration, you can access the slot data via `re_gen_passthrough` o
                     setattr(self.options, key, opt.from_any(value))
 ```
 
-The last thing to do is inform UT that your world can generate without a YAML.
+The last thing you can do is inform UT that your world can generate without a YAML. This is not necessary to do, but it may be convenient. It does mean that someone cannot edit their local YAML to see what would have been in logic had they chosen different options.
 
 ```python
 class MyWorld(World):

--- a/worlds/tracker/docs/apworld-integration.md
+++ b/worlds/tracker/docs/apworld-integration.md
@@ -45,7 +45,7 @@ You may also want to adjust your world's behaviour in other functions to reduce 
     def create_regions(self) -> None:
         is_ut = getattr(self.multiworld, "generation_is_fake", False)
         if self.randomly_rolled_property == 1 or is_ut:
-            # This location will always be created by UT regardless of options
+            # This location will always be created by UT regardless of what UT happens to roll
             self.create_location(...)
 ```
 
@@ -63,7 +63,7 @@ You can also make it so a YAML is not required to generate for your world. To do
         }
 ```
 
-To make implementation simpler, instead of the large amount of adjustments you'd likely have to make in `interpret_slot_data`, you can instead turn it into a static method that simply returns the slot data. This will inform UT that instead of doing an initial generation when it opens, it will do a regen once connected to the multiworld.
+To make implementation simpler, instead of the large amount of adjustments you'd likely have to make in `interpret_slot_data`, you can instead turn it into a static method that simply returns the slot data. This will inform UT that instead of doing an initial generation when it opens, it will do a regeneration once connected to the multiworld.
 
 ```python
     @staticmethod
@@ -72,7 +72,7 @@ To make implementation simpler, instead of the large amount of adjustments you'd
         return slot_data
 ```
 
-During the regen, you can access the slot data via `re_gen_passthrough` on the multiworld object. Early in gen you can inspect this object to set any instance attributes or options needed from the slot data so your later functions will behave as expected.
+During the regeneration, you can access the slot data via `re_gen_passthrough` on the multiworld object. Early in the generation you can inspect this object to set any instance attributes or options needed from the slot data so your later functions will behave as expected.
 
 ```python
     def generate_early(self) -> None:

--- a/worlds/tracker/docs/client-integration.md
+++ b/worlds/tracker/docs/client-integration.md
@@ -1,4 +1,8 @@
-# Adding a tracker tab to your CommonClient client
+# Client integration
+
+This document describes how you can integrate Universal Tracker into your own game's client and take advantage of its features.
+
+## Adding a tracker tab to your CommonClient client
 
 With the addition of ctx.make_gui() in 0.5.1 adding a UT tracker tab is very simplified,
 When you import CommonContext, try and import the UT context instead
@@ -34,7 +38,7 @@ if gui_enabled:
     ctx.run_gui()
 ```
 
-# Calling UT's tracker engine directly
+## Calling UT's tracker engine directly
 
 This one is a bit stranger because UT is built off of client code that doesn't need a reason to run if there is no connection, but the functionality is fully there still. 
 Here's an example that instantiates the ctx object without a connection, runs generation, and then picks the correct player id from UT's internal multiworld.
@@ -71,7 +75,7 @@ print(get_in_logic(ctx, items=[16777224, 16777227, 16777289], locations=[1677736
 # [16777370, 16777410]
 ```
 
-# Adding a map page
+## Adding a map page
 
 Worlds can define a structure with the following fields in order to inform UT that a poptracker pack has been embeded
 
@@ -113,14 +117,14 @@ class UTPackPath(FilePath):
 
 The contents of maps.json and locations.json are the same as poptracker format with the exception that all logic is derived from UT's internal world, and the location names must match exactly with AP location names
 
-# World flags
+## World flags
 
 UT supports a number of world flags that determine how UT will handle the world, the following is the current list
 
  * `disable_ut` : This causes UT to ignore the world, to be used only if the world is known to have issues when loaded in UT and fixing it would be more trouble then it's worth (Merged game/existing compatent poptracker etc)
  * `ut_can_gen_without_yaml` : Tells UT that the game will do a full regen
 
-# Command Line Interface
+## Command Line Interface
 
 UT provides two args that allow it to run as a "single shot" command line utility
 
@@ -139,6 +143,6 @@ For example
 python .\Launcher.py "Universal Tracker" -- --nogui --list Player1:None@localhost
 ```
 
-# Adding In-Logic Callbacks
+## Adding In-Logic Callbacks
 
 To be filled out later


### PR DESCRIPTION
## What is this fixing or adding?

Adds a document to describe the different ways an apworld can integrate with UT. Also renamed `integrating.md` to `client-integration.md` to make it more clear.

## How was this tested?

👁️ 

## If this makes graphical changes, please attach screenshots.

github supports md rendering