### PR TITLE
Do not reload map if already loaded

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -300,6 +300,8 @@ class TrackerGameContext(CommonContext):
             map_id = self.tracker_world.map_page_index(self.stored_data.get(key, ""))
             if not self.auto_tab or map_id < 0 or map_id >= len(self.maps):
                 return  # special case, don't load a new map
+        if self.map_id == map_id:
+            return  # map already loaded
         m = None
         if isinstance(map_id, str) and not map_id.isdecimal():
             for map in self.maps:
@@ -312,6 +314,9 @@ class TrackerGameContext(CommonContext):
         else:
             if isinstance(map_id, str):
                 map_id = int(map_id)
+            if map_id not in self.maps:
+                logger.error("Attempted to load a map that doesn't exist")
+                return
             m = self.maps[map_id]
         self.map_id = map_id
         location_name_to_id = AutoWorld.AutoWorldRegister.world_types[self.game].location_name_to_id

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -300,7 +300,7 @@ class TrackerGameContext(CommonContext):
             map_id = self.tracker_world.map_page_index(self.stored_data.get(key, ""))
             if not self.auto_tab or map_id < 0 or map_id >= len(self.maps):
                 return  # special case, don't load a new map
-        if self.map_id == map_id:
+        if self.map_id is not None and self.map_id == map_id:
             return  # map already loaded
         m = None
         if isinstance(map_id, str) and not map_id.isdecimal():
@@ -314,7 +314,7 @@ class TrackerGameContext(CommonContext):
         else:
             if isinstance(map_id, str):
                 map_id = int(map_id)
-            if map_id not in self.maps:
+            if map_id is None or map_id < 0 or map_id >= len(self.maps):
                 logger.error("Attempted to load a map that doesn't exist")
                 return
             m = self.maps[map_id]


### PR DESCRIPTION
## What is this fixing or adding?

Prevents the entire map page from reloading a map if it's already the loaded map. Should make it significantly more responsive on MD. 

Also snuck in a bit of extra error handling

## How was this tested?

see astalon thread

## If this makes graphical changes, please attach screenshots.

nah