### PR TITLE
Add text to kivymd incompat crash

### DIFF
--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -7,6 +7,15 @@ from collections import Counter
 
 
 def launch_client(*args):
+    from Utils import messagebox, version_tuple
+    if version_tuple < (0, 6, 2):
+        from CommonClient import gui_enabled
+        if gui_enabled:
+            messagebox("Failure", "Running incompatible version of AP; either downgrade UT or upgrade AP", True)
+        else:
+            print("Running incompatible version of AP; either downgrade UT or upgrade AP")
+        return
+
     from worlds.LauncherComponents import launch
     from .TrackerClient import launch as TCMain
     launch(TCMain, name="Universal Tracker client", args=args)


### PR DESCRIPTION
## What is this fixing or adding?
adds a descriptive crash for kivymd incompat so people at least have a chance to self serve

## How was this tested?
`python launcher.py "Universal Tracker"`
`python launcher.py "Universal Tracker" -- --nogui`
`python launcher.py` and clicking the ut button

on a modified 0.6.2 with an old version and shipped as an apworld on a local 0.6.1

## If this makes graphical changes, please attach screenshots.
