### PR TITLE
Allow map scaling above source resolution

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -26,6 +26,7 @@
         ApAsyncImage:
             id: tracker_map
             source: app.source
+            fit_mode: "contain"
         Widget:
             id: location_canvas
             pos_hint: {'center_x': 0.5, 'center_y': 0.5}


### PR DESCRIPTION
This changes the fit_mode Kivy property so maps can scale above their source resolution. I made this with virtually no knowledge of Kivy after skimming Kivy's image docs, skimming the source code, and making a guess that worked, so if this is hacky and there's a more idiomatic way to do this, I'm all ears.

I also have no idea why it thinks the last line has changed.