### PR TITLE
/event_locations command

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -42,24 +42,24 @@ def get_ut_color(color: str)->str:
     from kivy.properties import StringProperty
     class UTTextColor(Widget):
         in_logic: ClassVar[str] = StringProperty("")
-        glitched: ClassVar[str] = StringProperty("") 
-        out_of_logic: ClassVar[str] = StringProperty("") 
-        collected: ClassVar[str] = StringProperty("") 
-        in_logic_glitched: ClassVar[str] = StringProperty("") 
-        out_of_logic_glitched: ClassVar[str] = StringProperty("") 
-        mixed_logic: ClassVar[str] = StringProperty("") 
-        collected_light: ClassVar[str] = StringProperty("") 
-        hinted: ClassVar[str] = StringProperty("") 
-        hinted_in_logic: ClassVar[str] = StringProperty("") 
-        hinted_out_of_logic: ClassVar[str] = StringProperty("") 
-        hinted_glitched: ClassVar[str] = StringProperty("") 
+        glitched: ClassVar[str] = StringProperty("")
+        out_of_logic: ClassVar[str] = StringProperty("")
+        collected: ClassVar[str] = StringProperty("")
+        in_logic_glitched: ClassVar[str] = StringProperty("")
+        out_of_logic_glitched: ClassVar[str] = StringProperty("")
+        mixed_logic: ClassVar[str] = StringProperty("")
+        collected_light: ClassVar[str] = StringProperty("")
+        hinted: ClassVar[str] = StringProperty("")
+        hinted_in_logic: ClassVar[str] = StringProperty("")
+        hinted_out_of_logic: ClassVar[str] = StringProperty("")
+        hinted_glitched: ClassVar[str] = StringProperty("")
         excluded: ClassVar[str] = StringProperty("")
-        unconnected: ClassVar[str] = StringProperty("") 
+        unconnected: ClassVar[str] = StringProperty("")
     if not hasattr(get_ut_color,"utTextColor"):
         get_ut_color.utTextColor = UTTextColor()
     return str(getattr(get_ut_color.utTextColor,color,"DD00FF"))
-    
-    
+
+
 class TrackerCommandProcessor(ClientCommandProcessor):
     ctx: "TrackerGameContext"
 
@@ -89,6 +89,15 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         for event in sorted(currentState.events):
             if filter_text in event:
                 logger.info(event)
+
+    @mark_raw
+    def _cmd_event_locations(self, filter_text: str = ""):
+        """Print the list of current event locations in logic"""
+        logger.info("Event locations in logic:")
+        currentState = self.ctx.updateTracker()
+        for event_location in sorted(currentState.event_locations):
+            if filter_text in event_location:
+                logger.info(event_location)
 
     @mark_raw
     def _cmd_manually_collect(self, item_name: str = ""):
@@ -322,7 +331,7 @@ class TrackerGameContext(CommonContext):
             # ctx.load_map()
             for location in self.server_locations:
                 relevent_coords = self.coord_dict.get(location, [])
-                
+
                 if location in self.checked_locations or location in self.tracker_core.ignored_locations:
                     status = "collected"
                 elif location in self.tracker_core.locations_available:
@@ -536,7 +545,7 @@ class TrackerGameContext(CommonContext):
 
         class TrackerTooltip(ToolTip):
             pass
-    
+
         class TrackerView(MDRecycleView):
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
@@ -566,14 +575,14 @@ class TrackerGameContext(CommonContext):
                 super().__init__(**kwargs)
                 self._tooltip = TrackerTooltip(text="Test")
                 self._tooltip.markup = True
-            
+
             def on_enter(self):
                 self._tooltip.text = self.get_text()
                 self.display_tooltip()
 
             def on_leave(self):
                 self.animation_tooltip_dismiss()
-            
+
             def transform_to_pop_coords(self,x,y):
                 x2 = (x)
                 y2 = (self.tracker_page.height - y)
@@ -584,7 +593,7 @@ class TrackerGameContext(CommonContext):
                 x5 = x4 + self.width/2
                 y5 = y4 + self.width/2
                 return (x5,y5)
-            
+
             def on_mouse_pos(self, window, pos): #this does nothing, but it's kept here to make adding debug prints easier
                 return super().on_mouse_pos(window, pos)
 
@@ -593,7 +602,7 @@ class TrackerGameContext(CommonContext):
                     return self.border_point
                 else:
                     return self.tracker_page.to_window(x,y)
-            
+
             def to_widget(self, x, y):
                 return self.transform_to_pop_coords(*self.tracker_page.to_widget(x,y))
 
@@ -601,7 +610,7 @@ class TrackerGameContext(CommonContext):
                 if location in self.locationDict:
                     if self.locationDict[location] != status:
                         self.locationDict[location] = status
-            
+
             def get_text(self):
                 ctx = manager.get_running_app().ctx
                 location_id_to_name = AutoWorld.AutoWorldRegister.world_types[ctx.game].location_id_to_name
@@ -610,12 +619,12 @@ class TrackerGameContext(CommonContext):
                     color = get_ut_color("collected_light")
                     if status in ["in_logic","out_of_logic","glitched","hinted_in_logic","hinted_out_of_logic","hinted_glitched"]:
                         color = get_ut_color(status)
-                    sReturn.append(f"{location_id_to_name[loc]} : [color={color}]{status}[/color]") 
+                    sReturn.append(f"{location_id_to_name[loc]} : [color={color}]{status}[/color]")
                 return "\n".join(sReturn)
 
             def update_color(self, locationDict):
                 return
-            
+
         class APLocationMixed(ApLocation):
             from kivy.properties import ColorProperty
             color = ColorProperty("#"+get_ut_color("error"))
@@ -917,7 +926,7 @@ class TrackerGameContext(CommonContext):
                     self.updateTracker()
                 else:
                     asyncio.create_task(wait_for_items(self),name="UT Delay function") #if we don't get new items, delay for a bit first
-                self.watcher_task = asyncio.create_task(game_watcher(self), name="GameWatcher") #This shouldn't be needed, but technically 
+                self.watcher_task = asyncio.create_task(game_watcher(self), name="GameWatcher") #This shouldn't be needed, but technically
             elif cmd == 'RoomUpdate':
                 if not (self.items_handling & 0b010):
                     self.scout_checked_locations()
@@ -949,7 +958,7 @@ class TrackerGameContext(CommonContext):
                              "Then try to reproduce with the debug launcher and post in the Discord channel")
             self.disconnected_intentionally = True
             raise e
-        
+
     def update_location_icon_coords(self):
         icon_key = self.tracker_world.location_setting_key
         temp_ret = self.tracker_world.location_icon_coords(self.map_id,self.stored_data.get(icon_key, ""))
@@ -1026,7 +1035,7 @@ def get_logical_path(ctx: TrackerGameContext, dest_name: str):
     current_world = ctx.tracker_core.get_current_world()
     assert current_world
     if dest_name in current_world.location_name_to_id:
-        
+
         dest_id = current_world.location_name_to_id[dest_name]
         if dest_id not in ctx.server_locations:
             logger.error("Location not found")

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -42,24 +42,24 @@ def get_ut_color(color: str)->str:
     from kivy.properties import StringProperty
     class UTTextColor(Widget):
         in_logic: ClassVar[str] = StringProperty("")
-        glitched: ClassVar[str] = StringProperty("")
-        out_of_logic: ClassVar[str] = StringProperty("")
-        collected: ClassVar[str] = StringProperty("")
-        in_logic_glitched: ClassVar[str] = StringProperty("")
-        out_of_logic_glitched: ClassVar[str] = StringProperty("")
-        mixed_logic: ClassVar[str] = StringProperty("")
-        collected_light: ClassVar[str] = StringProperty("")
-        hinted: ClassVar[str] = StringProperty("")
-        hinted_in_logic: ClassVar[str] = StringProperty("")
-        hinted_out_of_logic: ClassVar[str] = StringProperty("")
-        hinted_glitched: ClassVar[str] = StringProperty("")
+        glitched: ClassVar[str] = StringProperty("") 
+        out_of_logic: ClassVar[str] = StringProperty("") 
+        collected: ClassVar[str] = StringProperty("") 
+        in_logic_glitched: ClassVar[str] = StringProperty("") 
+        out_of_logic_glitched: ClassVar[str] = StringProperty("") 
+        mixed_logic: ClassVar[str] = StringProperty("") 
+        collected_light: ClassVar[str] = StringProperty("") 
+        hinted: ClassVar[str] = StringProperty("") 
+        hinted_in_logic: ClassVar[str] = StringProperty("") 
+        hinted_out_of_logic: ClassVar[str] = StringProperty("") 
+        hinted_glitched: ClassVar[str] = StringProperty("") 
         excluded: ClassVar[str] = StringProperty("")
-        unconnected: ClassVar[str] = StringProperty("")
+        unconnected: ClassVar[str] = StringProperty("") 
     if not hasattr(get_ut_color,"utTextColor"):
         get_ut_color.utTextColor = UTTextColor()
     return str(getattr(get_ut_color.utTextColor,color,"DD00FF"))
-
-
+    
+    
 class TrackerCommandProcessor(ClientCommandProcessor):
     ctx: "TrackerGameContext"
 
@@ -331,7 +331,7 @@ class TrackerGameContext(CommonContext):
             # ctx.load_map()
             for location in self.server_locations:
                 relevent_coords = self.coord_dict.get(location, [])
-
+                
                 if location in self.checked_locations or location in self.tracker_core.ignored_locations:
                     status = "collected"
                 elif location in self.tracker_core.locations_available:
@@ -545,7 +545,7 @@ class TrackerGameContext(CommonContext):
 
         class TrackerTooltip(ToolTip):
             pass
-
+    
         class TrackerView(MDRecycleView):
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
@@ -575,14 +575,14 @@ class TrackerGameContext(CommonContext):
                 super().__init__(**kwargs)
                 self._tooltip = TrackerTooltip(text="Test")
                 self._tooltip.markup = True
-
+            
             def on_enter(self):
                 self._tooltip.text = self.get_text()
                 self.display_tooltip()
 
             def on_leave(self):
                 self.animation_tooltip_dismiss()
-
+            
             def transform_to_pop_coords(self,x,y):
                 x2 = (x)
                 y2 = (self.tracker_page.height - y)
@@ -593,7 +593,7 @@ class TrackerGameContext(CommonContext):
                 x5 = x4 + self.width/2
                 y5 = y4 + self.width/2
                 return (x5,y5)
-
+            
             def on_mouse_pos(self, window, pos): #this does nothing, but it's kept here to make adding debug prints easier
                 return super().on_mouse_pos(window, pos)
 
@@ -602,7 +602,7 @@ class TrackerGameContext(CommonContext):
                     return self.border_point
                 else:
                     return self.tracker_page.to_window(x,y)
-
+            
             def to_widget(self, x, y):
                 return self.transform_to_pop_coords(*self.tracker_page.to_widget(x,y))
 
@@ -610,7 +610,7 @@ class TrackerGameContext(CommonContext):
                 if location in self.locationDict:
                     if self.locationDict[location] != status:
                         self.locationDict[location] = status
-
+            
             def get_text(self):
                 ctx = manager.get_running_app().ctx
                 location_id_to_name = AutoWorld.AutoWorldRegister.world_types[ctx.game].location_id_to_name
@@ -619,12 +619,12 @@ class TrackerGameContext(CommonContext):
                     color = get_ut_color("collected_light")
                     if status in ["in_logic","out_of_logic","glitched","hinted_in_logic","hinted_out_of_logic","hinted_glitched"]:
                         color = get_ut_color(status)
-                    sReturn.append(f"{location_id_to_name[loc]} : [color={color}]{status}[/color]")
+                    sReturn.append(f"{location_id_to_name[loc]} : [color={color}]{status}[/color]") 
                 return "\n".join(sReturn)
 
             def update_color(self, locationDict):
                 return
-
+            
         class APLocationMixed(ApLocation):
             from kivy.properties import ColorProperty
             color = ColorProperty("#"+get_ut_color("error"))
@@ -926,7 +926,7 @@ class TrackerGameContext(CommonContext):
                     self.updateTracker()
                 else:
                     asyncio.create_task(wait_for_items(self),name="UT Delay function") #if we don't get new items, delay for a bit first
-                self.watcher_task = asyncio.create_task(game_watcher(self), name="GameWatcher") #This shouldn't be needed, but technically
+                self.watcher_task = asyncio.create_task(game_watcher(self), name="GameWatcher") #This shouldn't be needed, but technically 
             elif cmd == 'RoomUpdate':
                 if not (self.items_handling & 0b010):
                     self.scout_checked_locations()
@@ -958,7 +958,7 @@ class TrackerGameContext(CommonContext):
                              "Then try to reproduce with the debug launcher and post in the Discord channel")
             self.disconnected_intentionally = True
             raise e
-
+        
     def update_location_icon_coords(self):
         icon_key = self.tracker_world.location_setting_key
         temp_ret = self.tracker_world.location_icon_coords(self.map_id,self.stored_data.get(icon_key, ""))
@@ -1035,7 +1035,7 @@ def get_logical_path(ctx: TrackerGameContext, dest_name: str):
     current_world = ctx.tracker_core.get_current_world()
     assert current_world
     if dest_name in current_world.location_name_to_id:
-
+        
         dest_id = current_world.location_name_to_id[dest_name]
         if dest_id not in ctx.server_locations:
             logger.error("Location not found")

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -19,7 +19,7 @@ from typing import Optional,Callable
 from NetUtils import NetworkItem
 
 
-
+    
 REGEN_WORLDS = {name for name, world in AutoWorld.AutoWorldRegister.world_types.items() if getattr(world, "ut_can_gen_without_yaml", False)}
 
 class TrackerCore():
@@ -68,21 +68,21 @@ class TrackerCore():
 
     def set_set_page(self,set_page:Optional[Callable[[str],None]]):
         self._set_page = set_page
-
+    
     def set_log_to_tab(self,log_to_tab:Optional[Callable[[str,bool],None]]):
         self._log_to_tab = log_to_tab
-
+    
     def set_clear_page(self, clear_page:Optional[Callable[[],None]]):
         self._clear_page = clear_page
-
+    
     def set_get_ut_color(self,get_ut_color:Optional[Callable[[str],str]]):
         self._get_ut_color = get_ut_color
-
+    
     def get_current_world(self):
         if self.player_id and self.multiworld:
             return self.multiworld.worlds[self.player_id]
         return None
-
+    
     def set_page(self, line: str):
         if self._set_page:
             self._set_page(line)
@@ -92,10 +92,10 @@ class TrackerCore():
 
     def set_items_received(self, items_received:list[NetworkItem]):
         self.tracker_items_received = items_received
-
+    
     def set_hints(self,hints:list[int]):
         self.hints = hints
-
+    
     def log_to_tab(self,line: str, sort: bool = False):
         if self._log_to_tab:
             self._log_to_tab(line,sort)
@@ -115,7 +115,7 @@ class TrackerCore():
         self.slot = slot
         self.slot_name = slot_name
         self.team = team
-
+    
     def set_stored_data(self,stored_data:dict[str, Any]):
         if stored_data:
             self.stored_data = stored_data
@@ -134,7 +134,7 @@ class TrackerCore():
             return True
         else:
             return False
-
+        
     def _set_host_settings(self):
         from . import TrackerWorld
         tracker_settings = TrackerWorld.settings
@@ -148,7 +148,7 @@ class TrackerCore():
             report_type = "Region"
         return tracker_settings['player_files_path'], report_type, tracker_settings[
             'hide_excluded_locations'], tracker_settings["use_split_map_icons"]
-
+    
     def run_generator(self, slot_data: dict | None = None, override_yaml_path: str | None = None, super_override_yaml_path: str|None = None):
         def move_slots(args: "Namespace", slot_name: str):
             """
@@ -282,7 +282,7 @@ class TrackerCore():
                 break
 
         return multiworld
-
+    
     def updateTracker(self) -> CurrentTrackerState:
         if self.player_id is None or self.multiworld is None:
             self.logger.error("Player YAML not installed or Generator failed")
@@ -338,7 +338,7 @@ class TrackerCore():
                 if (temp_loc.address in self.missing_locations):
                     # logger.info("YES rechable (" + temp_loc.name + ")")
                     region = ""
-                    if temp_loc.parent_region is not None:
+                    if temp_loc.parent_region is not None: 
                         region = temp_loc.parent_region.name
                     temp_name = temp_loc.name
                     if temp_loc.address in self.location_alias_map:
@@ -434,7 +434,7 @@ class TrackerCore():
         self.glitched_locations = glitches_locations
 
         return CurrentTrackerState(all_items, prog_items, glitches_locations, events, event_locations, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state)
-
+    
     def write_empty_yaml(self, game, player_name, tempdir):
         import json
         import os

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -19,7 +19,7 @@ from typing import Optional,Callable
 from NetUtils import NetworkItem
 
 
-    
+
 REGEN_WORLDS = {name for name, world in AutoWorld.AutoWorldRegister.world_types.items() if getattr(world, "ut_can_gen_without_yaml", False)}
 
 class TrackerCore():
@@ -68,13 +68,13 @@ class TrackerCore():
 
     def set_set_page(self,set_page:Optional[Callable[[str],None]]):
         self._set_page = set_page
-    
+
     def set_log_to_tab(self,log_to_tab:Optional[Callable[[str,bool],None]]):
         self._log_to_tab = log_to_tab
-    
+
     def set_clear_page(self, clear_page:Optional[Callable[[],None]]):
         self._clear_page = clear_page
-    
+
     def set_get_ut_color(self,get_ut_color:Optional[Callable[[str],str]]):
         self._get_ut_color = get_ut_color
 
@@ -82,24 +82,24 @@ class TrackerCore():
         if self.player_id and self.multiworld:
             return self.multiworld.worlds[self.player_id]
         return None
-    
+
     def set_page(self, line: str):
         if self._set_page:
             self._set_page(line)
-    
+
     def set_missing_locations(self,missing_locations:set[int]):
         self.missing_locations = missing_locations
 
     def set_items_received(self, items_received:list[NetworkItem]):
         self.tracker_items_received = items_received
-    
+
     def set_hints(self,hints:list[int]):
         self.hints = hints
-    
+
     def log_to_tab(self,line: str, sort: bool = False):
         if self._log_to_tab:
             self._log_to_tab(line,sort)
-    
+
     def clear_page(self):
         if self._clear_page:
             self._clear_page()
@@ -115,7 +115,7 @@ class TrackerCore():
         self.slot = slot
         self.slot_name = slot_name
         self.team = team
-    
+
     def set_stored_data(self,stored_data:dict[str, Any]):
         if stored_data:
             self.stored_data = stored_data
@@ -134,7 +134,7 @@ class TrackerCore():
             return True
         else:
             return False
-        
+
     def _set_host_settings(self):
         from . import TrackerWorld
         tracker_settings = TrackerWorld.settings
@@ -148,7 +148,7 @@ class TrackerCore():
             report_type = "Region"
         return tracker_settings['player_files_path'], report_type, tracker_settings[
             'hide_excluded_locations'], tracker_settings["use_split_map_icons"]
-    
+
     def run_generator(self, slot_data: dict | None = None, override_yaml_path: str | None = None, super_override_yaml_path: str|None = None):
         def move_slots(args: "Namespace", slot_name: str):
             """
@@ -282,7 +282,7 @@ class TrackerCore():
                 break
 
         return multiworld
-    
+
     def updateTracker(self) -> CurrentTrackerState:
         if self.player_id is None or self.multiworld is None:
             self.logger.error("Player YAML not installed or Generator failed")
@@ -372,6 +372,7 @@ class TrackerCore():
                 self.log_to_tab("ERROR: location " + temp_loc.name + " broke something, report this to discord")
                 pass
         events = [location.item.name for location in state.advancements if location.player == self.player_id]
+        event_locations = [location.name for location in state.advancements if location.player == self.player_id]
 
         unconnected_entrances = [entrance for region in state.reachable_regions[self.player_id] for entrance in region.exits if entrance.can_reach(state) and entrance.connected_region is None]
 
@@ -399,7 +400,7 @@ class TrackerCore():
                         if (temp_loc.address in self.missing_locations):
                             glitches_locations.append(temp_loc.name)
                             region = ""
-                            if temp_loc.parent_region is not None:  
+                            if temp_loc.parent_region is not None:
                                 region = temp_loc.parent_region.name
                             temp_name = temp_loc.name
                             if temp_loc.address in self.location_alias_map:
@@ -432,8 +433,8 @@ class TrackerCore():
                         pass
         self.glitched_locations = glitches_locations
 
-        return CurrentTrackerState(all_items, prog_items, glitches_locations, events, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state)
-    
+        return CurrentTrackerState(all_items, prog_items, glitches_locations, events, event_locations, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state)
+
     def write_empty_yaml(self, game, player_name, tempdir):
         import json
         import os

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -77,7 +77,7 @@ class TrackerCore():
     
     def set_get_ut_color(self,get_ut_color:Optional[Callable[[str],str]]):
         self._get_ut_color = get_ut_color
-    
+
     def get_current_world(self):
         if self.player_id and self.multiworld:
             return self.multiworld.worlds[self.player_id]
@@ -86,7 +86,7 @@ class TrackerCore():
     def set_page(self, line: str):
         if self._set_page:
             self._set_page(line)
-
+    
     def set_missing_locations(self,missing_locations:set[int]):
         self.missing_locations = missing_locations
 
@@ -99,7 +99,7 @@ class TrackerCore():
     def log_to_tab(self,line: str, sort: bool = False):
         if self._log_to_tab:
             self._log_to_tab(line,sort)
-
+    
     def clear_page(self):
         if self._clear_page:
             self._clear_page()
@@ -338,7 +338,7 @@ class TrackerCore():
                 if (temp_loc.address in self.missing_locations):
                     # logger.info("YES rechable (" + temp_loc.name + ")")
                     region = ""
-                    if temp_loc.parent_region is not None: 
+                    if temp_loc.parent_region is not None:
                         region = temp_loc.parent_region.name
                     temp_name = temp_loc.name
                     if temp_loc.address in self.location_alias_map:
@@ -400,7 +400,7 @@ class TrackerCore():
                         if (temp_loc.address in self.missing_locations):
                             glitches_locations.append(temp_loc.name)
                             region = ""
-                            if temp_loc.parent_region is not None:
+                            if temp_loc.parent_region is not None:  
                                 region = temp_loc.parent_region.name
                             temp_name = temp_loc.name
                             if temp_loc.address in self.location_alias_map:

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -56,7 +56,7 @@ class TrackerSettings(Group):
 
     class HideExcluded(Bool):
         """Have the UT tab ignore excluded locations"""
-
+    
     class UseSplitMapIcons(Bool):
         """Use split icons rather then mixed for the UT map tab"""
 

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -27,6 +27,7 @@ class CurrentTrackerState(NamedTuple):
     prog_items: Counter
     glitched_locations: list[str]
     events: list[str]
+    event_locations: list[str]
     in_logic_locations: list[str]
     in_logic_regions: list[str]
     unconnected_entrances: list[Entrance]
@@ -36,7 +37,7 @@ class CurrentTrackerState(NamedTuple):
 
     @staticmethod
     def init_empty_state() -> "CurrentTrackerState":
-        return CurrentTrackerState(Counter(),Counter(),[],[],[],[],[],[],[],None)
+        return CurrentTrackerState(Counter(),Counter(),[],[],[],[],[],[],[],[],None)
 
 class DeferredEntranceMode(Enum):
     forced = "on"
@@ -55,7 +56,7 @@ class TrackerSettings(Group):
 
     class HideExcluded(Bool):
         """Have the UT tab ignore excluded locations"""
-    
+
     class UseSplitMapIcons(Bool):
         """Use split icons rather then mixed for the UT map tab"""
 


### PR DESCRIPTION
## What is this fixing or adding?
A command that lists event locations that are in logic, with optional filter text. Sorry about the whitespaces.

## How was this tested?
See screenshots. Done on a seed of Donkey Kong 64 with barely any items, to make sure that locations shown are only the ones that are in logic.

## If this makes graphical changes, please attach screenshots.
<img width="594" height="227" alt="image" src="https://github.com/user-attachments/assets/a317f0fa-7359-4641-90f9-da20e65045ff" />
<img width="473" height="472" alt="image" src="https://github.com/user-attachments/assets/c6ae3ba6-2904-438b-885b-bdcd8089ca30" />
<img width="419" height="327" alt="image" src="https://github.com/user-attachments/assets/904244a8-6967-4ce7-b04a-eb808e94bfa2" />
