### PR TITLE
Universal Tracker: map back to Poptracker Entrance Name for tooltip

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -704,7 +704,15 @@ class TrackerGameContext(CommonContext):
                         color = get_ut_color("collected_light")
                     elif status == "passable":
                         color = get_ut_color("in_logic")
-                    sReturn.append(f"{entrance} : [color={color}]{status}[/color]")
+                    poptracker_entrance_mapping: dict[str, str] | None = ctx.tracker_world.poptracker_entrance_mapping
+                    if poptracker_entrance_mapping:
+                        try:
+                            entrance_name = next(key for key in poptracker_entrance_mapping if poptracker_entrance_mapping[key] == entrance)
+                        except StopIteration:
+                            entrance_name = entrance
+                    else:
+                        entrance_name = entrance
+                    sReturn.append(f"{entrance_name} : [color={color}]{status}[/color]")
                     if host_world:
                         real_entrance = host_world.get_entrance(entrance)
                         if real_entrance.connected_region:


### PR DESCRIPTION
## What is this fixing or adding?
Use the locations.json name for entrances instead of the AP entrance name.

## How was this tested?
With the Death's Door deferred entrance tracker

## If this makes graphical changes, please attach screenshots.
<img width="576" height="465" alt="image" src="https://github.com/user-attachments/assets/39d280c5-c1b4-4bdb-b867-6eda928a2d1b" />
