### PR TITLE
Add GUI elements for map tracker

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -14,15 +14,38 @@
         orientation: 'vertical'
         spacing: dp(3)
 
+<CheckItem>:
+    size_hint: None, None
+    size: self.minimum_size
+    MDCheckbox:
+        id: checkitem_box
+        active: root.active
+        on_active: root.active = self.active
+    MDLabel:
+        id: checkitem_label
+        adaptive_size: True
+        text: root.text
+
 <VisualTracker>:
     BoxLayout:
         orientation: "vertical"
-        # DropDown
-        #     id: map_list
-        #     Button:
-        #         text: "First Item"
-        #     Button:
-        #         text: "Second Item"
+        BoxLayout:
+            orientation: "horizontal"
+            pos_hint: {'center_x': 0.5}
+            size_hint: None, None
+            size: self.minimum_size
+            CheckItem:
+                id: auto_tab_checkitem
+                text: "Auto Tab"
+                active: app.auto_tab
+                on_active: app.on_auto_tab_active(*args)
+                padding: [20, 0]
+            MDDropDownItem:
+                id: map_list
+                on_release: app.open_map_dropdown(self)
+                MDDropDownItemText:
+                    id: drop_text
+                    text: "Current Map: " + app.current_map
         ApAsyncImage:
             id: tracker_map
             source: app.source

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -251,7 +251,6 @@ class TrackerGameContext(CommonContext):
     ldeferred_dict: dict[str,list] = {}
     map_page_coords_func = lambda *args: {}
     watcher_task = None
-    auto_tab = True
     update_callback: Callable[[list[str]], bool] | None = None
     region_callback: Callable[[list[str]], bool] | None = None
     events_callback: Callable[[list[str]], bool] | None = None
@@ -262,6 +261,20 @@ class TrackerGameContext(CommonContext):
     use_split = True
     re_gen_passthrough = None
     local_items: list[NetworkItem] = []
+
+    _auto_tab = True
+
+    @property
+    def auto_tab(self):
+        return self._auto_tab
+
+    @auto_tab.setter
+    def auto_tab(self, value):
+        self._auto_tab = value
+        self.ui.auto_tab = value
+        if value:
+            self.load_map(None)
+            self.updateTracker()
 
     @property
     def tracker_items_received(self):
@@ -407,6 +420,59 @@ class TrackerGameContext(CommonContext):
 
         return updateTracker_ret
 
+    def parse_layout_node(self, node, curr_path, is_tab=False):
+        if is_tab:
+            name = node["title"]
+            curr_path = name if curr_path is None else f"{curr_path}/{name}"
+        else:
+            name = None
+        maps = []
+
+        if "type" in node and node["type"] == "map":
+            maps = node["maps"]
+            if curr_path is not None:
+                for m in maps:
+                    self.map_to_name[m] = curr_path
+        elif "content" in node:
+            if isinstance(node["content"], list):
+                for item in node["content"]:
+                    result = self.parse_layout_node(item, curr_path)
+                    if isinstance(result, list):
+                        maps.extend(result)
+                    elif result:
+                        maps.append(result)
+            else:
+                result = self.parse_layout_node(node["content"], curr_path)
+                if result:
+                    maps = result
+        elif "tabs" in node:
+            if isinstance(node["tabs"], list):
+                for item in node["tabs"]:
+                    result = self.parse_layout_node(item, curr_path, True)
+                    if isinstance(result, list):
+                        maps.extend(result)
+                    elif result:
+                        maps.append(result)
+            else:
+                result = self.parse_layout_node(node["tabs"], curr_path, True)
+                if result:
+                    maps = result
+
+        return (name, maps) if name is not None else maps
+
+    def parse_layouts(self):
+        all_layouts = []
+        self.map_to_name = {}
+        for layout in self.layouts:
+            maps = []
+            for key, node in layout.items():
+                result = self.parse_layout_node(node, None)
+                if result:
+                    maps.extend(result)
+            if maps:
+                all_layouts.extend(maps)
+        self.map_groups = all_layouts
+
     def load_pack(self):
         assert self.tracker_core.player_id is not None
         assert self.tracker_world is not None
@@ -414,6 +480,7 @@ class TrackerGameContext(CommonContext):
         assert current_world
         self.maps = []
         self.locs = []
+        self.layouts = []
         if self.tracker_world.external_pack_key:
             assert current_world.settings
             try:
@@ -431,6 +498,8 @@ class TrackerGameContext(CommonContext):
                             self.maps += load_json_zip(packRef, f"{map_page}")
                         for loc_page in self.tracker_world.map_page_locations:
                             self.locs += load_json_zip(packRef, f"{loc_page}")
+                        for layout_page in self.tracker_world.map_page_layouts:
+                            self.layouts.append(load_json_zip(packRef, f"{layout_page}"))
                     else:
                         current_world.settings.update({self.tracker_world.external_pack_key: ""}) #failed to find a pack, prompt next launch
                         current_world.settings._changed = True
@@ -452,6 +521,9 @@ class TrackerGameContext(CommonContext):
                 self.maps += load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{map_page}")
             for loc_page in self.tracker_world.map_page_locations:
                 self.locs += load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{loc_page}")
+            for layout_page in self.tracker_world.map_page_layouts:
+                self.layouts += load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{layout_page}")
+        self.parse_layouts()
         self.load_map(None)
 
     def load_map(self, map_id: Union[int, str, None]):
@@ -483,6 +555,10 @@ class TrackerGameContext(CommonContext):
                 return
             m = self.maps[map_id]
         self.map_id = map_id
+        if self.map_to_name is not None:
+            self.ui.current_map = self.map_to_name.get(m["name"], m["name"])
+        else:
+            self.ui.current_map = m["name"]
         location_name_to_id = AutoWorld.AutoWorldRegister.world_types[self.game].location_name_to_id
         # m = [m for m in self.maps if m["name"] == map_name]
         if self.tracker_world.external_pack_key:
@@ -626,6 +702,10 @@ class TrackerGameContext(CommonContext):
         from kivy.metrics import dp
         from kvui import ApAsyncImage, ToolTip
         from .TrackerKivy import SomethingNeatJustToMakePythonHappy
+
+        class CheckItem(BoxLayout):
+            text = StringProperty()
+            active = BooleanProperty()
 
         class TrackerLayout(BoxLayout):
             pass
@@ -919,6 +999,9 @@ class TrackerGameContext(CommonContext):
         ui = super().make_gui()  # before the kivy imports so kvui gets loaded first
         from kvui import HintLog, HintLabel, TooltipLabel
         from kivy.properties import StringProperty, NumericProperty, BooleanProperty
+        from kivymd.uix.menu import MDDropdownMenu
+        from kivy.metrics import dp
+        from kivy.animation import Animation
         from kvui import ImageLoader
 
         class TrackerManager(ui):
@@ -928,6 +1011,8 @@ class TrackerGameContext(CommonContext):
             loc_border = NumericProperty(5)
             enable_map = BooleanProperty(False)
             iconSource = StringProperty("")
+            current_map = StringProperty("")
+            auto_tab = BooleanProperty(True)
             base_title = f"Tracker {UT_VERSION} for AP version"  # core appends ap version so this works
 
             def build(self):
@@ -987,6 +1072,63 @@ class TrackerGameContext(CommonContext):
                     self.ctx.disconnected_intentionally = True
                     raise e
                 return super().update_hints()
+
+            def set_dropdown_items(self, menu: MDDropdownMenu, menu_items):
+                menu.items = menu_items
+
+                menu.set_menu_properties()
+                menu.position = menu.adjust_position()
+                if menu.width <= 100:
+                    menu.width = dp(240)
+                menu._tar_x, menu._tar_y = menu.get_target_pos()
+
+                anim = Animation(
+                    height=menu.target_height,
+                    x=menu._tar_x,
+                    y=menu._tar_y - menu.target_height,
+                    scale_value_center=menu.caller.center,
+
+                    duration=menu.hide_duration*2,
+                    transition=menu.hide_transition,
+                )
+                anim.start(menu)
+
+            def create_dropdown_menu_items(self, menu: MDDropdownMenu, groups: list[tuple[str, list]]):
+                menu_items = []
+                for group in groups:
+                    if isinstance(group[1], list) and len(group[1]) == 1 and isinstance(group[1][0], str):
+                       trailing_icon = ""
+                    else:
+                       trailing_icon = "menu-right"
+                    menu_items.append({"text": group[0], "trailing_icon": trailing_icon, "on_release": lambda menu=menu, x=group[1]: self.map_dropdown_callback(menu, x)})
+                return menu_items
+
+            def open_map_dropdown(self, item):
+                dropdown_menu = MDDropdownMenu(caller=item, hor_growth="right", ver_growth="down")
+                if self.ctx.map_groups:
+                    menu_items = self.create_dropdown_menu_items(dropdown_menu, self.ctx.map_groups)
+                else:
+                    menu_items = [
+                        *[{"text": m["name"], "on_release": lambda i=i: self.map_dropdown_callback(dropdown_menu, i)} for i, m in enumerate(self.ctx.maps)]
+                    ]
+                dropdown_menu.items = menu_items
+                dropdown_menu.open()
+
+            def map_dropdown_callback(self, menu: MDDropdownMenu, group_item):
+                if not isinstance(group_item, list):
+                    self.ctx.load_map(group_item)
+                    self.ctx.updateTracker()
+                elif isinstance(group_item, list) and len(group_item) == 1 and isinstance(group_item[0], str):
+                    self.ctx.load_map(group_item[0])
+                    self.ctx.updateTracker()
+                else:
+                    menu_items = [{"text": "Return", "leading_icon": "menu-left", "on_release": lambda menu=menu, items=menu.items: self.set_dropdown_items(menu, items)}]
+                    menu_items.extend(self.create_dropdown_menu_items(menu, group_item))
+
+                    self.set_dropdown_items(menu, menu_items)
+
+            def on_auto_tab_active(self, checkitem, value):
+                self.ctx.auto_tab = value
 
         self.load_kv()
         return TrackerManager

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -522,7 +522,7 @@ class TrackerGameContext(CommonContext):
             for loc_page in self.tracker_world.map_page_locations:
                 self.locs += load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{loc_page}")
             for layout_page in self.tracker_world.map_page_layouts:
-                self.layouts += load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{layout_page}")
+                self.layouts.append(load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{layout_page}"))
         self.parse_layouts()
         self.load_map(None)
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -431,8 +431,11 @@ class TrackerGameContext(CommonContext):
         if "type" in node and node["type"] == "map":
             maps = node["maps"]
             if curr_path is not None:
-                for m in maps:
-                    self.map_to_name[m] = curr_path
+                if len(maps) == 1:
+                    self.map_to_name[maps[0]] = curr_path
+                else:
+                    for m in maps:
+                        self.map_to_name[m] = f"{curr_path}/{m}"
         elif "content" in node:
             if isinstance(node["content"], list):
                 for item in node["content"]:
@@ -460,9 +463,26 @@ class TrackerGameContext(CommonContext):
 
         return (name, maps) if name is not None else maps
 
-    def parse_layouts(self):
-        all_layouts = []
+    def parse_map_group_node_names(self, node, curr_path):
+        if isinstance(node, str):
+            self.map_to_name[node] = curr_path
+        else:
+            name = node[0]
+            curr_path = name if curr_path is None else f"{curr_path}/{name}"
+            if isinstance(node[1], list):
+                for x in node[1]:
+                    self.parse_map_group_node_names(x, curr_path)
+            else:
+                self.parse_map_group_node_names(node[1], curr_path)
+
+    def parse_map_groups(self):
         self.map_to_name = {}
+        if self.tracker_world.map_page_groups is not None:
+            self.map_groups = self.tracker_world.map_page_groups
+            for x in self.map_groups:
+                self.parse_map_group_node_names(x, None)
+            return
+        all_layouts = []
         for layout in self.layouts:
             maps = []
             for key, node in layout.items():
@@ -523,7 +543,7 @@ class TrackerGameContext(CommonContext):
                 self.locs += load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{loc_page}")
             for layout_page in self.tracker_world.map_page_layouts:
                 self.layouts.append(load_json(PACK_NAME, f"/{self.tracker_world.map_page_folder}/{layout_page}"))
-        self.parse_layouts()
+        self.parse_map_groups()
         self.load_map(None)
 
     def load_map(self, map_id: Union[int, str, None]):
@@ -1096,11 +1116,18 @@ class TrackerGameContext(CommonContext):
             def create_dropdown_menu_items(self, menu: MDDropdownMenu, groups: list[tuple[str, list]]):
                 menu_items = []
                 for group in groups:
-                    if isinstance(group[1], list) and len(group[1]) == 1 and isinstance(group[1][0], str):
-                       trailing_icon = ""
+                    if isinstance(group, str):
+                        name = group
+                        x = group
+                        trailing_icon = ""
                     else:
-                       trailing_icon = "menu-right"
-                    menu_items.append({"text": group[0], "trailing_icon": trailing_icon, "on_release": lambda menu=menu, x=group[1]: self.map_dropdown_callback(menu, x)})
+                        name = group[0]
+                        x = group[1]
+                        if isinstance(x, list) and len(x) == 1 and isinstance(x[0], str) or isinstance(x, str):
+                           trailing_icon = ""
+                        else:
+                           trailing_icon = "menu-right"
+                    menu_items.append({"text": name, "trailing_icon": trailing_icon, "on_release": lambda menu=menu, x=x: self.map_dropdown_callback(menu, x)})
                 return menu_items
 
             def open_map_dropdown(self, item):

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -107,6 +107,9 @@ class UTMapTabData:
     map_page_locations: list[str]
     """The relative paths within the map_page_folder of the location.json"""
 
+    map_page_layouts: list[str]
+    """The relative paths within the map_page_folder of the layout.json"""
+
     map_page_setting_key: str
     """Data storage key used to determine which page should be loaded"""
 
@@ -130,9 +133,9 @@ class UTMapTabData:
 
     def __init__(
             self, player_id, team_id, map_page_folder: str = "", map_page_maps: list[str] | str = "",
-            map_page_locations: list[str] | str = "", map_page_setting_key: str | None = None,
-            map_page_index: Callable[[Any], int] | None = None, external_pack_key: str = "",
-            poptracker_name_mapping: dict[str, int] | None = None,
+            map_page_locations: list[str] | str = "", map_page_layouts: list[str] | str | None = None,
+            map_page_setting_key: str | None = None, map_page_index: Callable[[Any], int] | None = None,
+            external_pack_key: str = "", poptracker_name_mapping: dict[str, int] | None = None,
             location_setting_key: str|None = None,
             location_icon_coords: Callable[[int, Any], tuple[int,int]]|None= None,
             poptracker_entrance_mapping: dict[str, str]|None = None, **kwargs):
@@ -145,6 +148,12 @@ class UTMapTabData:
             self.map_page_locations = [map_page_locations]
         else:
             self.map_page_locations = map_page_locations
+        if isinstance(map_page_layouts, str):
+            self.map_page_layouts = [map_page_layouts]
+        elif isinstance(map_page_layouts, list):
+            self.map_page_layouts = map_page_layouts
+        else:
+            self.map_page_layouts = []
         self.map_page_setting_key = map_page_setting_key
         if isinstance(self.map_page_setting_key, str):
             self.map_page_setting_key = self.map_page_setting_key.format(player=player_id, team=team_id)

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -108,7 +108,10 @@ class UTMapTabData:
     """The relative paths within the map_page_folder of the location.json"""
 
     map_page_layouts: list[str]
-    """The relative paths within the map_page_folder of the layout.json"""
+    """The relative paths within the map_page_folder of the layout.json. Mutually exclusive with map_page_groups"""
+
+    map_page_groups: list[tuple[str, list]]
+    """Map page groups. Mutually exclusive with map_page_layouts"""
 
     map_page_setting_key: str
     """Data storage key used to determine which page should be loaded"""
@@ -134,6 +137,7 @@ class UTMapTabData:
     def __init__(
             self, player_id, team_id, map_page_folder: str = "", map_page_maps: list[str] | str = "",
             map_page_locations: list[str] | str = "", map_page_layouts: list[str] | str | None = None,
+            map_page_groups: list[tuple[str, list]] | None  = None,
             map_page_setting_key: str | None = None, map_page_index: Callable[[Any], int] | None = None,
             external_pack_key: str = "", poptracker_name_mapping: dict[str, int] | None = None,
             location_setting_key: str|None = None,
@@ -154,6 +158,7 @@ class UTMapTabData:
             self.map_page_layouts = map_page_layouts
         else:
             self.map_page_layouts = []
+        self.map_page_groups = map_page_groups
         self.map_page_setting_key = map_page_setting_key
         if isinstance(self.map_page_setting_key, str):
             self.map_page_setting_key = self.map_page_setting_key.format(player=player_id, team=team_id)


### PR DESCRIPTION
## What is this fixing or adding?
Adds a dropdown for loading maps and a checkbox for toggling Auto Tabbing.
Also adds an optional `map_page_layouts` key to UTMapTabData. If it exists it will be used for parsing poptracker layouts to create groups for maps

## How was this tested?
Tested the map tab with Astalon, Pokemon B/W, and a modified SMW apworld. I haven't tested Auto Tabbing other than toggling it off/on.

## If this makes graphical changes, please attach screenshots.
<img width="802" height="632" alt="UT map dropdown" src="https://github.com/user-attachments/assets/ac06b232-cc03-4e39-8418-e1f4d30fe7a8" />
