### PR TITLE
Properly support default names for maps

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -483,24 +483,26 @@ class TrackerGameContext(CommonContext):
 
         return (name, maps) if name is not None else maps
 
-    def parse_map_group_node_names(self, node, curr_path):
+    def parse_map_group_node_names(self, node: str | tuple, curr_path: str, has_siblings: bool):
         if isinstance(node, str):
+            if has_siblings:
+                curr_path = node if curr_path is None else f"{curr_path}/{node}"
             self.map_to_name[node] = curr_path
         else:
             name = node[0]
             curr_path = name if curr_path is None else f"{curr_path}/{name}"
             if isinstance(node[1], list):
                 for x in node[1]:
-                    self.parse_map_group_node_names(x, curr_path)
+                    self.parse_map_group_node_names(x, curr_path, len(node[1]) > 1)
             else:
-                self.parse_map_group_node_names(node[1], curr_path)
+                self.parse_map_group_node_names(node[1], curr_path, False)
 
     def parse_map_groups(self):
         self.map_to_name = {}
         if self.tracker_world.map_page_groups is not None:
             self.map_groups = self.tracker_world.map_page_groups
             for x in self.map_groups:
-                self.parse_map_group_node_names(x, None)
+                self.parse_map_group_node_names(x, None, True)
             return
         all_layouts = []
         for layout in self.layouts:


### PR DESCRIPTION
## What is this fixing or adding?
The map name shown in "Current map: " wouldn't show the full path/name if the map didn't have a custom name specified (Only if using the `map_page_groups` attribute)