### PR TITLE
Event Locations

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -91,6 +91,15 @@ class TrackerCommandProcessor(ClientCommandProcessor):
                 logger.info(event)
 
     @mark_raw
+    def _cmd_event_locations(self, filter_text: str = ""):
+        """Print the list of current event locations in logic"""
+        logger.info("Current Event Locations:")
+        currentState = self.ctx.updateTracker()
+        for location in sorted(currentState.event_locations):
+            if filter_text in location:
+                logger.info(location)
+
+    @mark_raw
     def _cmd_manually_collect(self, item_name: str = ""):
         """Manually adds an item name to the CollectionState to test"""
         self.ctx.tracker_core.manual_items.append(item_name)

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -378,7 +378,7 @@ class TrackerCore():
                 self.log_to_tab("ERROR: location " + temp_loc.name + " broke something, report this to discord")
                 pass
         events = [location.item.name for location in state.advancements if location.player == self.player_id]
-
+        event_locations = [location.name for location in state.advancements if location.player == self.player_id]
         unconnected_entrances = [entrance for region in state.reachable_regions[self.player_id] for entrance in region.exits if entrance.can_reach(state) and entrance.connected_region is None]
 
         self.locations_available = locations
@@ -439,7 +439,7 @@ class TrackerCore():
                         pass
         self.glitched_locations = glitches_locations
 
-        return CurrentTrackerState(all_items, prog_items, glitches_locations, events, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state)
+        return CurrentTrackerState(all_items, prog_items, glitches_locations, events, event_locations, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state)
     
     def write_empty_yaml(self, game, player_name, tempdir):
         import json

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -27,6 +27,7 @@ class CurrentTrackerState(NamedTuple):
     prog_items: Counter
     glitched_locations: list[str]
     events: list[str]
+    event_locations: list[str]
     in_logic_locations: list[str]
     in_logic_regions: list[str]
     unconnected_entrances: list[Entrance]
@@ -36,7 +37,7 @@ class CurrentTrackerState(NamedTuple):
 
     @staticmethod
     def init_empty_state() -> "CurrentTrackerState":
-        return CurrentTrackerState(Counter(),Counter(),[],[],[],[],[],[],[],None)
+        return CurrentTrackerState(Counter(),Counter(),[],[],[],[],[],[],[],[],None)
 
 class DeferredEntranceMode(Enum):
     """Determines how worlds should be allowed to use deferred entrances


### PR DESCRIPTION
I've reconfigured the way I track this fork of AP, so the PR had to be remade.

## What is this fixing or adding?
/event_locations chat command, which displays the event locations in logic

## How was this tested?
By producing what the screenshots shown with DK64, a game that has a lot of events, and giving myself items to see that it does add stuff in logic.

## If this makes graphical changes, please attach screenshots.
<img width="596" height="345" alt="image" src="https://github.com/user-attachments/assets/6678c062-c9d8-478c-9c81-d1259985bbc2" />
<img width="429" height="475" alt="image" src="https://github.com/user-attachments/assets/1803f26e-b636-4b9f-b6eb-e75a5d5fae82" />
<img width="395" height="384" alt="image" src="https://github.com/user-attachments/assets/60d8af79-4546-45ca-9800-3d408e042994" />
