### PR TITLE
Tracker Tab: Go mode indicator

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -88,9 +88,6 @@
     hinted_glitched:"ff9f20"
     excluded: "CFCFCF"
     unconnected: "89F336"
-    go_mode: "20ff20"
-    out_of_logic_go_mode: "ffff20"
-    not_go_mode: "cf1010"
 <ApAsyncImage>:
 
 <ApLocationIcon>:

--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -88,7 +88,9 @@
     hinted_glitched:"ff9f20"
     excluded: "CFCFCF"
     unconnected: "89F336"
-
+    go_mode: "20ff20"
+    out_of_logic_go_mode: "ffff20"
+    not_go_mode: "cf1010"
 <ApAsyncImage>:
 
 <ApLocationIcon>:

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -54,10 +54,20 @@ def get_ut_color(color: str)->str:
         hinted_out_of_logic: ClassVar[str] = StringProperty("") 
         hinted_glitched: ClassVar[str] = StringProperty("") 
         excluded: ClassVar[str] = StringProperty("")
-        unconnected: ClassVar[str] = StringProperty("") 
+        unconnected: ClassVar[str] = StringProperty("")
+        go_mode: ClassVar[str] = StringProperty("")
+        out_of_logic_go_mode: ClassVar[str] = StringProperty("")
+        not_go_mode: ClassVar[str] = StringProperty("")
     if not hasattr(get_ut_color,"utTextColor"):
         get_ut_color.utTextColor = UTTextColor()
     return str(getattr(get_ut_color.utTextColor,color,"DD00FF"))
+
+def get_go_mode_color(go_mode_status: str)->str:
+    if go_mode_status == "No":
+        return get_ut_color("not_go_mode")
+    elif go_mode_status == "Out of Logic":
+        return get_ut_color("out_of_logic_go_mode")
+    return get_ut_color("go_mode")
     
     
 class TrackerCommandProcessor(ClientCommandProcessor):
@@ -437,6 +447,8 @@ class TrackerGameContext(CommonContext):
             self.tracker_glitched_locs_label.text = f"Glitched: [color={get_ut_color('glitched')}]{len(updateTracker_ret.glitched_locations)}[/color]"
         if hasattr(self, "tracker_hinted_locs_label"):
             self.tracker_hinted_locs_label.text = f"Hinted: [color={get_ut_color('hinted_in_logic')}]{len(updateTracker_ret.hinted_locations)}[/color]"
+        if hasattr(self, "tracker_go_mode_label"):
+            self.tracker_go_mode_label.text = f"Go mode: [color={get_go_mode_color(updateTracker_ret.go_mode)}]{updateTracker_ret.go_mode}[/color]"
 
         return updateTracker_ret
 
@@ -991,12 +1003,15 @@ class TrackerGameContext(CommonContext):
             self.tracker_logic_locs_label = MDLabel(text="In Logic: 0", halign="center")
             self.tracker_glitched_locs_label = MDLabel(text=f"Glitched: [color={get_ut_color('glitched')}]0[/color]",  halign="center")
             self.tracker_hinted_locs_label = MDLabel(text=f"Hinted: [color={get_ut_color('hinted_in_logic')}]0[/color]", halign="center")
+            self.tracker_go_mode_label = MDLabel(text=f"Go Mode: [color={get_ut_color('not_go_mode')}]No[/color]", halign="center")
             self.tracker_glitched_locs_label.markup = True
             self.tracker_hinted_locs_label.markup = True
+            self.tracker_go_mode_label.markup = True
             tracker_header.add_widget(self.tracker_total_locs_label)
             tracker_header.add_widget(self.tracker_logic_locs_label)
             tracker_header.add_widget(self.tracker_glitched_locs_label)
             tracker_header.add_widget(self.tracker_hinted_locs_label)
+            tracker_header.add_widget(self.tracker_go_mode_label)
 
             # Adds the tracker list at the bottom
             tracker.add_widget(tracker_header)
@@ -1345,6 +1360,8 @@ class TrackerGameContext(CommonContext):
                 self.tracker_glitched_locs_label.text = f"Glitched: [color={get_ut_color('glitched')}]0[/color]"
             if hasattr(self, "tracker_hinted_locs_label"):
                 self.tracker_hinted_locs_label.text = f"Hinted: [color={get_ut_color('hinted_in_logic')}]0[/color]"
+            if hasattr(self, "tracker_go_mode_label"):
+                self.tracker_go_mode_label.text = f"Go Mode: [color={get_ut_color('not_go_mode')}]No[/color]"
             self.tracker_core.disconnect()
         self.local_items.clear()
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -55,19 +55,16 @@ def get_ut_color(color: str)->str:
         hinted_glitched: ClassVar[str] = StringProperty("") 
         excluded: ClassVar[str] = StringProperty("")
         unconnected: ClassVar[str] = StringProperty("")
-        go_mode: ClassVar[str] = StringProperty("")
-        out_of_logic_go_mode: ClassVar[str] = StringProperty("")
-        not_go_mode: ClassVar[str] = StringProperty("")
     if not hasattr(get_ut_color,"utTextColor"):
         get_ut_color.utTextColor = UTTextColor()
     return str(getattr(get_ut_color.utTextColor,color,"DD00FF"))
 
 def get_go_mode_color(go_mode_status: str)->str:
     if go_mode_status == "No":
-        return get_ut_color("not_go_mode")
-    elif go_mode_status == "Out of Logic":
-        return get_ut_color("out_of_logic_go_mode")
-    return get_ut_color("go_mode")
+        return get_ut_color("out_of_logic")
+    elif go_mode_status == "Glitched":
+        return get_ut_color("glitched")
+    return get_ut_color("in_logic")
     
     
 class TrackerCommandProcessor(ClientCommandProcessor):
@@ -1003,7 +1000,7 @@ class TrackerGameContext(CommonContext):
             self.tracker_logic_locs_label = MDLabel(text="In Logic: 0", halign="center")
             self.tracker_glitched_locs_label = MDLabel(text=f"Glitched: [color={get_ut_color('glitched')}]0[/color]",  halign="center")
             self.tracker_hinted_locs_label = MDLabel(text=f"Hinted: [color={get_ut_color('hinted_in_logic')}]0[/color]", halign="center")
-            self.tracker_go_mode_label = MDLabel(text=f"Go Mode: [color={get_ut_color('not_go_mode')}]No[/color]", halign="center")
+            self.tracker_go_mode_label = MDLabel(text=f"Go Mode: [color={get_ut_color('out_of_logic')}]No[/color]", halign="center")
             self.tracker_glitched_locs_label.markup = True
             self.tracker_hinted_locs_label.markup = True
             self.tracker_go_mode_label.markup = True
@@ -1361,7 +1358,7 @@ class TrackerGameContext(CommonContext):
             if hasattr(self, "tracker_hinted_locs_label"):
                 self.tracker_hinted_locs_label.text = f"Hinted: [color={get_ut_color('hinted_in_logic')}]0[/color]"
             if hasattr(self, "tracker_go_mode_label"):
-                self.tracker_go_mode_label.text = f"Go Mode: [color={get_ut_color('not_go_mode')}]No[/color]"
+                self.tracker_go_mode_label.text = f"Go Mode: [color={get_ut_color('out_of_logic')}]No[/color]"
             self.tracker_core.disconnect()
         self.local_items.clear()
 

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -380,7 +380,7 @@ class TrackerCore():
         events = [location.item.name for location in state.advancements if location.player == self.player_id]
 
         unconnected_entrances = [entrance for region in state.reachable_regions[self.player_id] for entrance in region.exits if entrance.can_reach(state) and entrance.connected_region is None]
-
+        go_mode_in_logic = self.multiworld.has_beaten_game(state, self.player_id)
         self.locations_available = locations
         glitches_item_name = getattr(self.multiworld.worlds[self.player_id],"glitches_item_name","")
         if glitches_item_name:
@@ -392,6 +392,7 @@ class TrackerCore():
             else:
                 state.sweep_for_advancements(
                     locations=[location for location in self.multiworld.get_locations(self.player_id) if (not location.address)])
+                go_mode_out_of_logic = self.multiworld.has_beaten_game(state, self.player_id)
                 for temp_loc in self.multiworld.get_reachable_locations(state, self.player_id):
                     if temp_loc.address is None or isinstance(temp_loc.address, list):
                         continue
@@ -439,7 +440,14 @@ class TrackerCore():
                         pass
         self.glitched_locations = glitches_locations
 
-        return CurrentTrackerState(all_items, prog_items, glitches_locations, events, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state)
+        go_mode_status: str
+        if go_mode_in_logic:
+            go_mode_status = "Yes"
+        elif go_mode_out_of_logic:
+            go_mode_status = "Out of Logic"
+        else:
+            go_mode_status = "No"
+        return CurrentTrackerState(all_items, prog_items, glitches_locations, events, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state, go_mode_status)
     
     def write_empty_yaml(self, game, player_name, tempdir):
         import json

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -444,7 +444,7 @@ class TrackerCore():
         if go_mode_in_logic:
             go_mode_status = "Yes"
         elif go_mode_out_of_logic:
-            go_mode_status = "Out of Logic"
+            go_mode_status = "Glitched"
         else:
             go_mode_status = "No"
         return CurrentTrackerState(all_items, prog_items, glitches_locations, events, callback_list, regions, unconnected_entrances, readable_locations, hinted_locations, state, go_mode_status)

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -385,6 +385,7 @@ class TrackerCore():
         go_mode_in_logic = self.multiworld.has_beaten_game(state, self.player_id)
         self.locations_available = locations
         glitches_item_name = getattr(self.multiworld.worlds[self.player_id],"glitches_item_name","")
+        glitched_go_mode = False
         if glitches_item_name:
             try:
                 world_item = self.multiworld.create_item(glitches_item_name, self.player_id)
@@ -394,7 +395,7 @@ class TrackerCore():
             else:
                 state.sweep_for_advancements(
                     locations=[location for location in self.multiworld.get_locations(self.player_id) if (not location.address)])
-                go_mode_out_of_logic = self.multiworld.has_beaten_game(state, self.player_id)
+                glitched_go_mode = self.multiworld.has_beaten_game(state, self.player_id)
                 for temp_loc in self.multiworld.get_reachable_locations(state, self.player_id):
                     if temp_loc.address is None or isinstance(temp_loc.address, list):
                         continue
@@ -446,7 +447,7 @@ class TrackerCore():
         go_mode_status: str
         if go_mode_in_logic:
             go_mode_status = "Yes"
-        elif go_mode_out_of_logic:
+        elif glitched_go_mode:
             go_mode_status = "Glitched"
         else:
             go_mode_status = "No"

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -33,10 +33,11 @@ class CurrentTrackerState(NamedTuple):
     readable_locations: list[str]
     hinted_locations: list
     state: Optional[CollectionState]
+    go_mode: str
 
     @staticmethod
     def init_empty_state() -> "CurrentTrackerState":
-        return CurrentTrackerState(Counter(),Counter(),[],[],[],[],[],[],[],None)
+        return CurrentTrackerState(Counter(),Counter(),[],[],[],[],[],[],[],None, "No")
 
 class DeferredEntranceMode(Enum):
     """Determines how worlds should be allowed to use deferred entrances


### PR DESCRIPTION
## What is this fixing or adding?
Adds an indicator in the header of the tracker tab to know if you're in go mode, out of logic go mode, or not in go mode.


## How was this tested?
Launching a new seed, giving me the required items to see that the go mode is available out of logic, see that it's good, give myself the items to make the go mode in logic, see that it's marked as in logic.

## If this makes graphical changes, please attach screenshots.
I tried reusing the colours that are already attributed to other things in UT. I'm particularly not a fan of the red or how long "Out of Logic" is.
<img width="806" height="156" alt="image" src="https://github.com/user-attachments/assets/73fc505f-7be5-4a2b-acf9-a891beedb476" />
<img width="835" height="157" alt="image" src="https://github.com/user-attachments/assets/3afa2c8e-6ff2-4049-81fe-25371ae7e44b" />
<img width="815" height="178" alt="image" src="https://github.com/user-attachments/assets/84343131-3737-4cea-8b52-a6774a0348eb" />
