### PR TITLE
TrackerClient: add command to list locations in logic

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -81,13 +81,14 @@ class TrackerCommandProcessor(ClientCommandProcessor):
             if filter_text in item:
                 logger.info(str(count) + "x: " + item)
 
-    @mark_raw
-    def _cmd_locations_in_logic(self, filter_text: str = ""):
-        """Print the list of locations currently accessible in logic"""
-        currentState = self.ctx.updateTracker()
-        for location in sorted(currentState.in_logic_locations):
-            if filter_text in location:
-                logger.info(location)
+    if not gui_enabled:
+        @mark_raw
+        def _cmd_locations_in_logic(self, filter_text: str = ""):
+            """Print the list of locations currently accessible in logic"""
+            currentState = self.ctx.updateTracker()
+            for location in sorted(currentState.in_logic_locations):
+                if filter_text in location:
+                    logger.info(location)
 
     @mark_raw
     def _cmd_event_inventory(self, filter_text: str = ""):

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -82,6 +82,14 @@ class TrackerCommandProcessor(ClientCommandProcessor):
                 logger.info(str(count) + "x: " + item)
 
     @mark_raw
+    def _cmd_locations_in_logic(self, filter_text: str = ""):
+        """Print the list of locations currently accessible in logic"""
+        currentState = self.ctx.updateTracker()
+        for location in sorted(currentState.in_logic_locations):
+            if filter_text in location:
+                logger.info(location)
+
+    @mark_raw
     def _cmd_event_inventory(self, filter_text: str = ""):
         """Print the list of current event items in the inventory"""
         logger.info("Current Inventory:")


### PR DESCRIPTION


## What is this fixing or adding?

Adds a command `/locations_in_logic` to list all in-logic locations

This is primarily for CLI mode, as there's presently no way (that I could find?) to show the list of in-logic locations that you see on the GUI


## How was this tested?

Editing the source, running the client on a locally-generated game, and testing the command in `--nogui` mode

## If this makes graphical changes, please attach screenshots.

<img width="495" height="288" alt="image" src="https://github.com/user-attachments/assets/7810b0e0-2a2d-445f-a7a7-8c600ffbe627" />

Not really graphical, but there it is working ¯\\\_(ツ)\_/¯
