### PR TITLE
Remove assumption that map and icon keys are different

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -1300,7 +1300,7 @@ class TrackerGameContext(CommonContext):
                         if args["key"] == key:
                             self.load_map(None)
                             self.updateTracker()
-                        elif args["key"] == icon_key:
+                        if args["key"] == icon_key:
                             self.update_location_icon_coords()
                     elif "keys" in args:
                         if icon_key in args["keys"]:


### PR DESCRIPTION
If the map index and icon key are the same, this results in the icon coordinates callback not being called when the map stays the same because of an early exit in load_map.

## How was this tested?

Along with the other PR, using Anodyne's implementation.
