### PR TITLE
Better fuzzy matching for /get_logical_path and /explain

### DIFF
--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -229,6 +229,8 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         if self.ctx.stored_data and "_read_race_mode" in self.ctx.stored_data and self.ctx.stored_data["_read_race_mode"]:
             logger.info("Logical Path is disabled during Race Mode")
             return
+        if self.ctx.ui:
+            self.ctx.ui.last_autofillable_command = "/get_logical_path"
         get_logical_path(self.ctx, dest_name)
     
     @mark_raw
@@ -240,6 +242,8 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         if self.ctx.stored_data and "_read_race_mode" in self.ctx.stored_data and self.ctx.stored_data["_read_race_mode"]:
             logger.info("Explain is disabled during Race Mode")
             return
+        if self.ctx.ui:
+            self.ctx.ui.last_autofillable_command = "/explain"
         explain(self.ctx, lookup_name)
 
     @mark_raw
@@ -1468,9 +1472,9 @@ def explain(ctx: TrackerGameContext, dest_name: str):
     elif dest_name in ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]:
         parent_region = ctx.tracker_core.multiworld.get_region(dest_name,ctx.tracker_core.player_id)
     else:
-        from Utils import get_fuzzy_results
-        results = get_fuzzy_results(dest_name,set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()).union(set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys())),limit=1)[0]
-        logger.error(f"Did you mean '{results[0]}' ({results[1]}% sure)? ")
+        from Utils import get_intended_text
+        _, _, response = get_intended_text(dest_name,set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()).union(set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys())))
+        logger.error(response)
         return
     if parent_region:
         if location:
@@ -1521,9 +1525,9 @@ def get_logical_path(ctx: TrackerGameContext, dest_name: str):
         if location.can_reach(state):
             relevent_region = location.parent_region
     else:
-        from Utils import get_fuzzy_results
-        results = get_fuzzy_results(dest_name,set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()).union(set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys())),limit=1)[0]
-        logger.error(f"Did you mean '{results[0]}' ({results[1]}% sure)? ")
+        from Utils import get_intended_text
+        _, _, response = get_intended_text(dest_name,set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()).union(set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys())))
+        logger.error(response)
         return
     if state:
         if relevent_region:

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -1454,9 +1454,18 @@ def explain(ctx: TrackerGameContext, dest_name: str):
         if returned_json:
             ctx.ui.print_json(returned_json)
             return
+
+    from Utils import get_intended_text
+    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id]}
+    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]}
+    result, usable, response = get_intended_text(dest_name, location_names.union(region_names))
+    if not usable:
+        logger.error(response)
+        return
+    dest_name = result
     parent_region = None
     location = None
-    if dest_name in ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id]:
+    if dest_name in location_names:
         dest_id = current_world.location_name_to_id[dest_name]
         if dest_id not in ctx.server_locations:
             logger.error("Location not found")
@@ -1469,11 +1478,9 @@ def explain(ctx: TrackerGameContext, dest_name: str):
         else:
             logger.info("Location doesn't have a rule that supports explanation")
         parent_region = location.parent_region
-    elif dest_name in ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]:
+    elif dest_name in region_names:
         parent_region = ctx.tracker_core.multiworld.get_region(dest_name,ctx.tracker_core.player_id)
     else:
-        from Utils import get_intended_text
-        _, _, response = get_intended_text(dest_name,set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()).union(set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys())))
         logger.error(response)
         return
     if parent_region:
@@ -1506,27 +1513,27 @@ def get_logical_path(ctx: TrackerGameContext, dest_name: str):
             ctx.ui.print_json(returned_json)
             return
 
-    if dest_name in [loc.name for loc in ctx.tracker_core.multiworld.get_locations(ctx.tracker_core.player_id)]:
+    from Utils import get_intended_text
+    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id]}
+    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]}
+    result, usable, response = get_intended_text(dest_name, location_names.union(region_names))
+    if not usable:
+        logger.error(response)
+        return
+    dest_name = result
+    if dest_name in location_names:
         location = ctx.tracker_core.multiworld.get_location(dest_name, ctx.tracker_core.player_id)
         state = ctx.updateTracker().state
         if not state: return
         if location.can_reach(state):
             relevent_region = location.parent_region
-    elif dest_name in ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]:
+    elif dest_name in region_names:
         relevent_region = ctx.tracker_core.multiworld.get_region(dest_name,ctx.tracker_core.player_id)
         state = ctx.updateTracker().state
         if not state: return
         if not relevent_region.can_reach(state):
             relevent_region = None
-    elif dest_name in ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id]:
-        location = ctx.tracker_core.multiworld.get_location(dest_name,ctx.tracker_core.player_id)
-        state = ctx.updateTracker().state
-        if not state: return
-        if location.can_reach(state):
-            relevent_region = location.parent_region
     else:
-        from Utils import get_intended_text
-        _, _, response = get_intended_text(dest_name,set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()).union(set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys())))
         logger.error(response)
         return
     if state:

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -1456,8 +1456,8 @@ def explain(ctx: TrackerGameContext, dest_name: str):
             return
 
     from Utils import get_intended_text
-    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()}
-    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys()}
+    location_names = set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id])
+    region_names = set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id])
     result, usable, response = get_intended_text(dest_name, location_names.union(region_names))
     if not usable:
         logger.error(response)
@@ -1514,8 +1514,8 @@ def get_logical_path(ctx: TrackerGameContext, dest_name: str):
             return
 
     from Utils import get_intended_text
-    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()}
-    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys()}
+    location_names = set(ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id])
+    region_names = set(ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id])
     result, usable, response = get_intended_text(dest_name, location_names.union(region_names))
     if not usable:
         logger.error(response)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -1456,8 +1456,8 @@ def explain(ctx: TrackerGameContext, dest_name: str):
             return
 
     from Utils import get_intended_text
-    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id]}
-    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]}
+    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()}
+    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys()}
     result, usable, response = get_intended_text(dest_name, location_names.union(region_names))
     if not usable:
         logger.error(response)
@@ -1514,8 +1514,8 @@ def get_logical_path(ctx: TrackerGameContext, dest_name: str):
             return
 
     from Utils import get_intended_text
-    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id]}
-    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id]}
+    location_names = {ctx.tracker_core.multiworld.regions.location_cache[ctx.tracker_core.player_id].keys()}
+    region_names = {ctx.tracker_core.multiworld.regions.region_cache[ctx.tracker_core.player_id].keys()}
     result, usable, response = get_intended_text(dest_name, location_names.union(region_names))
     if not usable:
         logger.error(response)


### PR DESCRIPTION
## What is this fixing or adding?

Makes `/get_logical_path` and `/explain` auto fuzzy match, no longer requiring you to type in the exact perfect name match. Also adds the ability to click the name the autofill the fuzzy match if it's not a good enough match, the same way `!hint` works.

## How was this tested?

manually

## If this makes graphical changes, please attach screenshots.

fuzzy match can be clicked on
<img width="806" height="139" alt="image" src="https://github.com/user-attachments/assets/6cdccff6-94e5-49ea-a375-be0f6f51a68b" />

matches close enough are auto picked
<img width="802" height="157" alt="image" src="https://github.com/user-attachments/assets/8913b160-7f5f-4a1d-a233-ae39595d9ad4" />

also works for `/explain`
<img width="802" height="200" alt="image" src="https://github.com/user-attachments/assets/772920b1-7f75-454e-88ae-7658e771262e" />