### PR TITLE
OSRS members logic performance improvements

### DIFF
--- a/worlds/osrsm/Items.py
+++ b/worlds/osrsm/Items.py
@@ -15,6 +15,19 @@ class OSRSMItem(Item):
     game: str = "Old School Runescape"
 
 
+class OSRSMTrainingItem(OSRSMItem):
+    skill_name: str
+    skill_level: int
+    pseudo_item_name: str
+
+    def __init__(self, skill_name: str, skill_level: int, player: int):
+        name = f"Training_{skill_name}_{skill_level}"
+        super().__init__(name, ItemClassification.progression, None, player)
+        self.skill_name = skill_name
+        self.skill_level = skill_level
+        self.pseudo_item_name = "_Max_Training_" + skill_name
+
+
 QP_Items: typing.List[str] = [
     ItemNames.QP_Cooks_Assistant,
     ItemNames.QP_Demon_Slayer,

--- a/worlds/osrsm/Items.py
+++ b/worlds/osrsm/Items.py
@@ -13,9 +13,11 @@ class ItemRow(typing.NamedTuple):
 
 class OSRSMItem(Item):
     game: str = "Old School Runescape"
+    item_type: typing.ClassVar[str] = "generic"
 
 
 class OSRSMTrainingItem(OSRSMItem):
+    item_type = "training"
     skill_name: str
     skill_level: int
     pseudo_item_name: str
@@ -26,6 +28,36 @@ class OSRSMTrainingItem(OSRSMItem):
         self.skill_name = skill_name
         self.skill_level = skill_level
         self.pseudo_item_name = "_Max_Training_" + skill_name
+
+
+class OSRSMQuestPointItem(OSRSMItem):
+    item_type = "quest_point"
+    quest_point_reward: int
+
+    def __init__(self, quest_point_reward: int, location_name: str, player: int):
+        name = f"QP {quest_point_reward} ({location_name})"
+        super().__init__(name, ItemClassification.progression, None, player)
+        self.quest_point_reward = quest_point_reward
+
+
+class OSRSMKudosItem(OSRSMItem):
+    item_type = "kudos"
+    kudos_reward: int
+
+    def __init__(self, kudos_reward: int, location_name: str, player: int):
+        name = f"Kudos {kudos_reward} ({location_name})"
+        super().__init__(name, ItemClassification.progression, None, player)
+        self.kudos_reward = kudos_reward
+
+
+class OSRSMCombatPointsItem(OSRSMItem):
+    item_type = "combat_points"
+    combat_point_reward: int
+
+    def __init__(self, combat_point_reward: int, location_name: str, player: int):
+        name = f"CombatPoints {combat_point_reward} ({location_name})"
+        super().__init__(name, ItemClassification.progression, None, player)
+        self.combat_point_reward = combat_point_reward
 
 
 QP_Items: typing.List[str] = [

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -7,7 +7,7 @@ from Fill import fill_restrictive, FillError
 from worlds.AutoWorld import WebWorld, World
 from Options import OptionError
 from .Items import OSRSMItem, starting_area_dict, chunksanity_starting_chunks, QP_Items, ItemRow, \
-    chunksanity_special_region_names
+    chunksanity_special_region_names, OSRSMTrainingItem
 from .Locations import OSRSMLocation
 from .Rules import *
 from .Options import OSRSMOptions, StartingArea
@@ -741,9 +741,9 @@ class OSRSMWorld(CachedRuleBuilderWorld):
         parent_region = self.get_region(training_row.parent_region)
         method = OSRSMLocation(self.player,f"Training {training_row.skill_name}: {training_row.task_name}",None,parent_region)
         if training_row.task_name == "Unlock ~|Herblore|~ after Druidic Ritual": #We don't want to be herblore 10 etc after druidic ritual
-            method.place_locked_item(self.create_event(f"Training_{training_row.skill_name}_{training_row.required_level+3}"))
+            method.place_locked_item(self.create_training_event(training_row.skill_name,training_row.required_level+3))
         else:
-            method.place_locked_item(self.create_event(f"Training_{training_row.skill_name}_{training_row.required_level+self.options.base_training_levels.value}"))
+            method.place_locked_item(self.create_training_event(training_row.skill_name,training_row.required_level+self.options.base_training_levels.value))
         method.show_in_spoiler = False
         parent_region.locations.append(method)
         self.training_to_data[method.name] = method
@@ -767,6 +767,9 @@ class OSRSMWorld(CachedRuleBuilderWorld):
     def create_event(self, event: str):
         # while we are at it, we can also add a helper to create events
         return OSRSMItem(event, ItemClassification.progression, None, self.player)
+
+    def create_training_event(self, skill_name: str, skill_level: int):
+        return OSRSMTrainingItem(skill_name, skill_level, self.player)
     
     def collect(self, state: CollectionState, item: Item) -> bool:
         if item.code:
@@ -787,15 +790,13 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                 state.add_item(item="Kudo",player=self.player,count=(qp_count-1))
             super().collect(state,self.create_event("Kudo"))
         elif item.name.startswith("Training_"):
-            name = item.name
-            last_underscore_index = name.rfind("_")
-            skill_level = int(name[last_underscore_index + 1:])
+            # Assert to help type checking, but keep performance on frozen AP or `-O` command line argument.
+            assert isinstance(item, OSRSMTrainingItem)
+            skill_level = item.skill_level
             # Training only counts up to level 99, anything above that is ignored.
             if skill_level < 100:
-                skill_name = name[len("Training_"):last_underscore_index]
-
                 # Check the current Max Training level for this skill, and increase it if `skill_level` is higher.
-                psuedo_item_name = "_Max_Training_" + skill_name
+                psuedo_item_name = item.pseudo_item_name
                 current_max_level = state.prog_items[self.player][psuedo_item_name]
                 if skill_level > current_max_level:
                     state.prog_items[self.player][psuedo_item_name] = skill_level
@@ -823,15 +824,15 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             if state.count(item.name, self.player) == 1:
                 # The last Training event for this level is being removed, so the Max Training psuedo-item may need to
                 # be updated.
-                name = item.name
-                last_underscore_index = name.rfind("_")
-                skill_level = int(name[last_underscore_index + 1:])
+                # Assert to help type checking, but keep performance on frozen AP or `-O` command line argument.
+                assert isinstance(item, OSRSMTrainingItem)
+                skill_level = item.skill_level
                 # Training only counts up to level 99, anything above that is ignored.
                 if skill_level < 100:
-                    skill_name = name[len("Training_"):last_underscore_index]
+                    skill_name = item.skill_name
                     # Check the current Max Training level for this skill, and decrease it if it is equal to
                     # `skill_level`.
-                    psuedo_item_name = "_Max_Training_" + skill_name
+                    psuedo_item_name = item.pseudo_item_name
                     current_max_level = state.prog_items[self.player][psuedo_item_name]
                     if current_max_level == skill_level:
                         # Find the next highest training level for this skill in the state.

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -539,11 +539,11 @@ class OSRSMWorld(CachedRuleBuilderWorld):
 
         if not self.options.disable_chunk_culling:
 
-            event_list = [loc for _,loc in self.multiworld.regions.location_cache[self.player].items() if not loc.address]
+            pre_placed_advancements = [loc for loc in self.get_locations() if loc.advancement]
                 
 
             all_state = base_state.copy()
-            all_state.sweep_for_advancements(locations=event_list)
+            all_state.sweep_for_advancements(locations=pre_placed_advancements)
             max_chance = len([loc for region in all_state.reachable_regions[self.player] for loc in region.locations if loc.address]) - len(itempool)
             base_itempool = itempool.copy()
             self.random.shuffle(base_itempool)
@@ -553,7 +553,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                 temp_state = base_state.copy()
                 for item in short_pool:
                     temp_state.remove(item)
-                temp_state.sweep_for_advancements(locations=event_list)
+                temp_state.sweep_for_advancements(locations=pre_placed_advancements)
                 if self.multiworld.completion_condition[self.player](temp_state):
                     curr_chance = len([loc for region in temp_state.reachable_regions[self.player] for loc in region.locations if loc.address]) - len(itempool)
                     for item in short_pool:

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -804,7 +804,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
         return OSRSMCombatPointsItem(location_row.combat_point_reward, location_row.name, self.player)
 
     def collect(self, state: CollectionState, item: Item) -> bool:
-        if item.code:
+        if item.code is not None:
             return super().collect(state,item)
         # Asserts help type checking, but keep performance on frozen AP (`-O` command line argument), because
         # isinstance is slow, and asserts cease to exist with `-O`.
@@ -836,7 +836,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
         return super().collect(state, item)
     
     def remove(self, state: CollectionState, item: Item) -> bool:
-        if item.code:
+        if item.code is not None:
             return super().remove(state,item)
         # Asserts help type checking, but keep performance on frozen AP (`-O` command line argument), because
         # isinstance is slow, and asserts cease to exist with `-O`.

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -827,7 +827,9 @@ class HasTraining(Rule["OSRSMWorld"],game="OSRSMWorld"):
     def _instantiate(self, world: "OSRSMWorld") -> Rule.Resolved:
         if self.skill_name in world.options.starting_skill_levels and self.skill_level <= world.options.starting_skill_levels[self.skill_name]:
             return True_.Resolved(player=world.player)
-        return self.Resolved(self.skill_name,self.skill_level,self.qp_run,self.qp_rise,tuple([f"Training_{self.skill_name}_{level}" for level in range(self.skill_level,100)]),player=world.player)
+        all_relevant_items = tuple([f"Training_{self.skill_name}_{level}" for level in range(0, 100)])
+        main_relevant_items = all_relevant_items[self.skill_level:]
+        return self.Resolved(self.skill_name,self.skill_level,self.qp_run,self.qp_rise,main_relevant_items,all_relevant_items,player=world.player)
 
     class Resolved(Rule.Resolved):
         skill_name: str
@@ -835,12 +837,19 @@ class HasTraining(Rule["OSRSMWorld"],game="OSRSMWorld"):
         qp_run: int
         qp_rise: int
         _relevent_items: tuple[str,...]
+        _all_relevant_items: tuple[str,...]
         skip_cache=True
 
         @override
         def _evaluate(self, state: CollectionState) -> bool:
-            return state.has_any(self._relevent_items,self.player) or \
-                state.has_any([f"Training_{self.skill_name}_{level}" for level in range(max(0,self.skill_level-self.qp_rise*(state.count("Quest Point",self.player)//self.qp_run)),self.skill_level)],self.player)
+            # Check for training between self.skill_level and 100.
+            if state.has_any(self._relevent_items,self.player):
+                return True
+            # Check for training from lower levels, accounting for qp_rise.
+            # `self.skill_level-self.qp_rise*(state.count("Quest Point",self.player)//self.qp_run)` to self.skill_level.
+            lower_bound = max(0,self.skill_level-self.qp_rise*(state.count("Quest Point",self.player)//self.qp_run))
+            qp_rise_relevant_items = self._all_relevant_items[lower_bound:self.skill_level]
+            return state.has_any(qp_rise_relevant_items,self.player)
 
         @override
         def item_dependencies(self) -> dict[str, set[int]]:

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -544,6 +544,8 @@ class OSRSMWorld(CachedRuleBuilderWorld):
 
             all_state = base_state.copy()
             all_state.sweep_for_advancements(locations=pre_placed_advancements)
+            if all_state.stale[self.player]:
+                all_state.update_reachable_regions(self.player)
             max_chance = len([loc for region in all_state.reachable_regions[self.player] for loc in region.locations if loc.address]) - len(itempool)
             base_itempool = itempool.copy()
             self.random.shuffle(base_itempool)
@@ -555,6 +557,8 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                     temp_state.remove(item)
                 temp_state.sweep_for_advancements(locations=pre_placed_advancements)
                 if self.multiworld.completion_condition[self.player](temp_state):
+                    if temp_state.stale[self.player]:
+                        temp_state.update_reachable_regions(self.player)
                     curr_chance = len([loc for region in temp_state.reachable_regions[self.player] for loc in region.locations if loc.address]) - len(itempool)
                     for item in short_pool:
                         rand_value = 0 if curr_chance < 0 else self.random.randint(0,max_chance)

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -786,6 +786,19 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             if qp_count > 1:
                 state.add_item(item="Kudo",player=self.player,count=(qp_count-1))
             super().collect(state,self.create_event("Kudo"))
+        elif item.name.startswith("Training_"):
+            name = item.name
+            last_underscore_index = name.rfind("_")
+            skill_level = int(name[last_underscore_index + 1:])
+            # Training only counts up to level 99, anything above that is ignored.
+            if skill_level < 100:
+                skill_name = name[len("Training_"):last_underscore_index]
+
+                # Check the current Max Training level for this skill, and increase it if `skill_level` is higher.
+                psuedo_item_name = "_Max_Training_" + skill_name
+                current_max_level = state.prog_items[self.player][psuedo_item_name]
+                if skill_level > current_max_level:
+                    state.prog_items[self.player][psuedo_item_name] = skill_level
         return super().collect(state, item)
     
     def remove(self, state: CollectionState, item: Item) -> bool:
@@ -806,6 +819,29 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             if qp_count > 1:
                 state.remove_item(item="Kudo",player=self.player,count=(qp_count-1))
             super().remove(state,self.create_event("Kudo"))
+        elif item.name.startswith("Training_"):
+            if state.count(item.name, self.player) == 1:
+                # The last Training event for this level is being removed, so the Max Training psuedo-item may need to
+                # be updated.
+                name = item.name
+                last_underscore_index = name.rfind("_")
+                skill_level = int(name[last_underscore_index + 1:])
+                # Training only counts up to level 99, anything above that is ignored.
+                if skill_level < 100:
+                    skill_name = name[len("Training_"):last_underscore_index]
+                    # Check the current Max Training level for this skill, and decrease it if it is equal to
+                    # `skill_level`.
+                    psuedo_item_name = "_Max_Training_" + skill_name
+                    current_max_level = state.prog_items[self.player][psuedo_item_name]
+                    if current_max_level == skill_level:
+                        # Find the next highest training level for this skill in the state.
+                        next_highest_level = 0
+                        for i in reversed(range(1, skill_level)):
+                            event_item_name = f"Training_{skill_name}_{i}"
+                            if state.has(event_item_name, self.player):
+                                next_highest_level = i
+                                break
+                        state.prog_items[self.player][psuedo_item_name] = next_highest_level
         return super().remove(state, item)
 
 
@@ -827,29 +863,26 @@ class HasTraining(Rule["OSRSMWorld"],game="OSRSMWorld"):
     def _instantiate(self, world: "OSRSMWorld") -> Rule.Resolved:
         if self.skill_name in world.options.starting_skill_levels and self.skill_level <= world.options.starting_skill_levels[self.skill_name]:
             return True_.Resolved(player=world.player)
-        all_relevant_items = tuple([f"Training_{self.skill_name}_{level}" for level in range(0, 100)])
-        main_relevant_items = all_relevant_items[self.skill_level:]
-        return self.Resolved(self.skill_name,self.skill_level,self.qp_run,self.qp_rise,main_relevant_items,all_relevant_items,player=world.player)
+        pseudo_item_name = f"_Max_Training_{self.skill_name}"
+        return self.Resolved(self.skill_name,self.skill_level,self.qp_run,self.qp_rise,pseudo_item_name,player=world.player)
 
     class Resolved(Rule.Resolved):
         skill_name: str
         skill_level: int
         qp_run: int
         qp_rise: int
-        _relevent_items: tuple[str,...]
-        _all_relevant_items: tuple[str,...]
+        _max_training_psuedo_item_name: str
         skip_cache=True
 
         @override
         def _evaluate(self, state: CollectionState) -> bool:
-            # Check for training between self.skill_level and 100.
-            if state.has_any(self._relevent_items,self.player):
+            # Check for training of self.skill_level and higher.
+            max_training_level = state.count(self._max_training_psuedo_item_name, self.player)
+            if max_training_level >= self.skill_level:
                 return True
-            # Check for training from lower levels, accounting for qp_rise.
-            # `self.skill_level-self.qp_rise*(state.count("Quest Point",self.player)//self.qp_run)` to self.skill_level.
-            lower_bound = max(0,self.skill_level-self.qp_rise*(state.count("Quest Point",self.player)//self.qp_run))
-            qp_rise_relevant_items = self._all_relevant_items[lower_bound:self.skill_level]
-            return state.has_any(qp_rise_relevant_items,self.player)
+            # Check for training from lower levels than self.skill_level, accounting for qp_rise.
+            allowed_lower_training_level = max(1,self.skill_level-self.qp_rise*(state.count("Quest Point",self.player)//self.qp_run))
+            return max_training_level >= allowed_lower_training_level
 
         @override
         def item_dependencies(self) -> dict[str, set[int]]:

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -298,8 +298,10 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             self.create_location(location)
         for sub_location in sub_quests:
             self.create_location(sub_location)
+        created_training_methods = []
         for training_method in training_methods:
-            self.create_training(training_method)
+            if self.create_training(training_method):
+                created_training_methods.append(training_method)
 
         # place "Victory" at the option from the yaml
 
@@ -520,9 +522,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                         self.set_rule(qp_loc,rule)
                 if location_row.kudos_reward > 0:
                     raise Exception("This shouldn't happen but i want to know if it does "+location_row.name)
-        for training_method in training_methods:
-            if training_method.parent_region in self.options.banned_chunks:
-                continue
+        for training_method in created_training_methods:
             if training_method.rule:
                 method = self.get_location(f"Training {training_method.skill_name}: {training_method.task_name}")
                 rule = self.generate_lambda(training_method.rule)
@@ -758,19 +758,26 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             qp_loc.place_locked_item(self.create_combat_points_event(location_row))
             region.locations.append(qp_loc)
     
-    def create_training(self, training_row:TrainingRow):
+    def create_training(self, training_row:TrainingRow) -> bool:
         if training_row.parent_region in self.options.banned_chunks:
-            return
+            return False
         parent_region = self.get_region(training_row.parent_region)
-        method = OSRSMLocation(self.player,f"Training {training_row.skill_name}: {training_row.task_name}",None,parent_region)
-        if training_row.task_name == "Unlock ~|Herblore|~ after Druidic Ritual": #We don't want to be herblore 10 etc after druidic ritual
-            method.place_locked_item(self.create_training_event(training_row.skill_name,training_row.required_level+3))
+
+        if training_row.task_name == "Unlock ~|Herblore|~ after Druidic Ritual":  # We don't want to be herblore 10 etc after druidic ritual
+            training_level = training_row.required_level + 3
         else:
-            method.place_locked_item(self.create_training_event(training_row.skill_name,training_row.required_level+self.options.base_training_levels.value))
+            training_level = training_row.required_level + self.options.base_training_levels.value
+        if training_level > 99:
+            # self.options.base_training_levels can push the required level over 99, making the training irrelevant.
+            return False
+
+        method = OSRSMLocation(self.player,f"Training {training_row.skill_name}: {training_row.task_name}",None,parent_region)
+        method.place_locked_item(self.create_training_event(training_row.skill_name, training_level))
         method.show_in_spoiler = False
         parent_region.locations.append(method)
         self.training_to_data[method.name] = method
         self.training_to_row[method.name] = training_row
+        return True
 
     def create_region(self, name: str) -> "Region":
         region = Region(name, self.player, self.multiworld)
@@ -826,13 +833,11 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             # Assert to help type checking, but keep performance on frozen AP or `-O` command line argument.
             assert isinstance(item, OSRSMTrainingItem)
             skill_level = item.skill_level
-            # Training only counts up to level 99, anything above that is ignored.
-            if skill_level < 100:
-                # Check the current Max Training level for this skill, and increase it if `skill_level` is higher.
-                psuedo_item_name = item.pseudo_item_name
-                current_max_level = state.prog_items[self.player][psuedo_item_name]
-                if skill_level > current_max_level:
-                    state.prog_items[self.player][psuedo_item_name] = skill_level
+            # Check the current Max Training level for this skill, and increase it if `skill_level` is higher.
+            psuedo_item_name = item.pseudo_item_name
+            current_max_level = state.prog_items[self.player][psuedo_item_name]
+            if skill_level > current_max_level:
+                state.prog_items[self.player][psuedo_item_name] = skill_level
         return super().collect(state, item)
     
     def remove(self, state: CollectionState, item: Item) -> bool:
@@ -861,22 +866,19 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                 # Assert to help type checking, but keep performance on frozen AP or `-O` command line argument.
                 assert isinstance(item, OSRSMTrainingItem)
                 skill_level = item.skill_level
-                # Training only counts up to level 99, anything above that is ignored.
-                if skill_level < 100:
-                    skill_name = item.skill_name
-                    # Check the current Max Training level for this skill, and decrease it if it is equal to
-                    # `skill_level`.
-                    psuedo_item_name = item.pseudo_item_name
-                    current_max_level = state.prog_items[self.player][psuedo_item_name]
-                    if current_max_level == skill_level:
-                        # Find the next highest training level for this skill in the state.
-                        next_highest_level = 0
-                        for i in reversed(range(1, skill_level)):
-                            event_item_name = f"Training_{skill_name}_{i}"
-                            if state.has(event_item_name, self.player):
-                                next_highest_level = i
-                                break
-                        state.prog_items[self.player][psuedo_item_name] = next_highest_level
+                skill_name = item.skill_name
+                # Check the current Max Training level for this skill, and decrease it if it is equal to `skill_level`.
+                psuedo_item_name = item.pseudo_item_name
+                current_max_level = state.prog_items[self.player][psuedo_item_name]
+                if current_max_level == skill_level:
+                    # Find the next highest training level for this skill in the state.
+                    next_highest_level = 0
+                    for i in reversed(range(1, skill_level)):
+                        event_item_name = f"Training_{skill_name}_{i}"
+                        if state.has(event_item_name, self.player):
+                            next_highest_level = i
+                            break
+                    state.prog_items[self.player][psuedo_item_name] = next_highest_level
         return super().remove(state, item)
 
 

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -7,7 +7,7 @@ from Fill import fill_restrictive, FillError
 from worlds.AutoWorld import WebWorld, World
 from Options import OptionError
 from .Items import OSRSMItem, starting_area_dict, chunksanity_starting_chunks, QP_Items, ItemRow, \
-    chunksanity_special_region_names, OSRSMTrainingItem
+    chunksanity_special_region_names, OSRSMTrainingItem, OSRSMQuestPointItem, OSRSMKudosItem, OSRSMCombatPointsItem
 from .Locations import OSRSMLocation
 from .Rules import *
 from .Options import OSRSMOptions, StartingArea
@@ -673,11 +673,11 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             #Don't do most of this, just add the events to precollected :)
             self.push_precollected(self.create_event(location_row.name))
             if location_row.quest_point_reward>0:
-                self.push_precollected(self.create_event(f"QP {location_row.quest_point_reward} ({location_row.name})"))
+                self.push_precollected(self.create_quest_point_event(location_row))
             if location_row.kudos_reward>0:
-                self.push_precollected(self.create_event(f"Kudos {location_row.kudos_reward} ({location_row.name})"))
+                self.push_precollected(self.create_kudos_event(location_row))
             if location_row.combat_point_reward > 0:
-                self.push_precollected(self.create_event(f"CombatPoints {location_row.combat_point_reward} ({location_row.name})"))
+                self.push_precollected(self.create_combat_points_event(location_row))
             return
         if location_row.parent_region in self.options.banned_chunks:
             return
@@ -716,7 +716,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             qp_loc.show_in_spoiler = False
             self.location_name_to_data[qp_name] = qp_loc
             qp_loc.parent_region = region
-            qp_loc.place_locked_item(self.create_event(f"QP {location_row.quest_point_reward} ({location_row.name})"))
+            qp_loc.place_locked_item(self.create_quest_point_event(location_row))
             region.locations.append(qp_loc)
         if location_row.kudos_reward > 0:
             qp_name = "Kudos: " + location_row.name
@@ -724,7 +724,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             qp_loc.show_in_spoiler = False
             self.location_name_to_data[qp_name] = qp_loc
             qp_loc.parent_region = region
-            qp_loc.place_locked_item(self.create_event(f"Kudos {location_row.kudos_reward} ({location_row.name})"))
+            qp_loc.place_locked_item(self.create_kudos_event(location_row))
             region.locations.append(qp_loc)
         if location_row.combat_point_reward > 0:
             qp_name = "CombatPoints: " + location_row.name
@@ -732,7 +732,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             qp_loc.show_in_spoiler = False
             self.location_name_to_data[qp_name] = qp_loc
             qp_loc.parent_region = region
-            qp_loc.place_locked_item(self.create_event(f"CombatPoints {location_row.combat_point_reward} ({location_row.name})"))
+            qp_loc.place_locked_item(self.create_combat_points_event(location_row))
             region.locations.append(qp_loc)
     
     def create_training(self, training_row:TrainingRow):
@@ -770,26 +770,42 @@ class OSRSMWorld(CachedRuleBuilderWorld):
 
     def create_training_event(self, skill_name: str, skill_level: int):
         return OSRSMTrainingItem(skill_name, skill_level, self.player)
-    
+
+    def create_quest_point_event(self, location_row: LocationRow):
+        return OSRSMQuestPointItem(location_row.quest_point_reward, location_row.name, self.player)
+
+    def create_kudos_event(self, location_row: LocationRow):
+        return OSRSMKudosItem(location_row.kudos_reward, location_row.name, self.player)
+
+    def create_combat_points_event(self, location_row: LocationRow):
+        return OSRSMCombatPointsItem(location_row.combat_point_reward, location_row.name, self.player)
+
     def collect(self, state: CollectionState, item: Item) -> bool:
         if item.code:
             return super().collect(state,item)
-        if item.name.startswith("QP "):
-            qp_count = int(item.name.split(" ",3)[1])
+        # Asserts help type checking, but keep performance on frozen AP (`-O` command line argument), because
+        # isinstance is slow, and asserts cease to exist with `-O`.
+        assert isinstance(item, OSRSMItem)
+        item_type = item.item_type
+        if item_type == "quest_point":
+            assert isinstance(item, OSRSMQuestPointItem)
+            qp_count = item.quest_point_reward
             if qp_count > 1:
                 state.add_item(item="Quest Point",player=self.player,count=(qp_count-1))
             super().collect(state,self.create_event("Quest Point"))
-        elif item.name.startswith("CombatPoints "):
-            qp_count = int(item.name.split(" ",3)[1])
-            if qp_count > 1:
-                state.add_item(item="Combat Point",player=self.player,count=(qp_count-1))
-            super().collect(state,self.create_event("Combat Point"))
-        elif item.name.startswith("Kudos "):
-            qp_count = int(item.name.split(" ",3)[1])
-            if qp_count > 1:
-                state.add_item(item="Kudo",player=self.player,count=(qp_count-1))
+        elif item_type == "combat_points":
+            assert isinstance(item, OSRSMCombatPointsItem)
+            combat_point_reward = item.combat_point_reward
+            if combat_point_reward > 1:
+                state.add_item(item="Combat Point", player=self.player, count=(combat_point_reward - 1))
+            super().collect(state, self.create_event("Combat Point"))
+        elif item_type == "kudos":
+            assert isinstance(item, OSRSMKudosItem)
+            kudos = item.kudos_reward
+            if kudos > 1:
+                state.add_item(item="Kudo",player=self.player,count=(kudos-1))
             super().collect(state,self.create_event("Kudo"))
-        elif item.name.startswith("Training_"):
+        elif item_type == "training":
             # Assert to help type checking, but keep performance on frozen AP or `-O` command line argument.
             assert isinstance(item, OSRSMTrainingItem)
             skill_level = item.skill_level
@@ -805,22 +821,29 @@ class OSRSMWorld(CachedRuleBuilderWorld):
     def remove(self, state: CollectionState, item: Item) -> bool:
         if item.code:
             return super().remove(state,item)
-        if item.name.startswith("QP "):
-            qp_count = int(item.name.split(" ",3)[1])
+        # Asserts help type checking, but keep performance on frozen AP (`-O` command line argument), because
+        # isinstance is slow, and asserts cease to exist with `-O`.
+        assert isinstance(item, OSRSMItem)
+        item_type = item.item_type
+        if item_type == "quest_point":
+            assert isinstance(item, OSRSMQuestPointItem)
+            qp_count = item.quest_point_reward
             if qp_count > 1:
                 state.remove_item(item="Quest Point",player=self.player,count=(qp_count-1))
             super().remove(state,self.create_event("Quest Point"))
-        elif item.name.startswith("CombatPoints "):
-            qp_count = int(item.name.split(" ",3)[1])
-            if qp_count > 1:
-                state.remove_item(item="Combat Point",player=self.player,count=(qp_count-1))
+        elif item_type == "combat_points":
+            assert isinstance(item, OSRSMCombatPointsItem)
+            combat_point_reward = item.combat_point_reward
+            if combat_point_reward > 1:
+                state.remove_item(item="Combat Point",player=self.player,count=(combat_point_reward-1))
             super().remove(state,self.create_event("Combat Point"))
-        elif item.name.startswith("Kudos "):
-            qp_count = int(item.name.split(" ",3)[1])
-            if qp_count > 1:
-                state.remove_item(item="Kudo",player=self.player,count=(qp_count-1))
+        elif item_type == "kudos":
+            assert isinstance(item, OSRSMKudosItem)
+            kudos = item.kudos_reward
+            if kudos > 1:
+                state.remove_item(item="Kudo",player=self.player,count=(kudos-1))
             super().remove(state,self.create_event("Kudo"))
-        elif item.name.startswith("Training_"):
+        elif item_type == "training":
             if state.count(item.name, self.player) == 1:
                 # The last Training event for this level is being removed, so the Max Training psuedo-item may need to
                 # be updated.

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -60,13 +60,14 @@ def _make_rule_builder_item_mapping() -> dict[str, str]:
         item_mapping.update(dict.fromkeys(map_from, map_to))
 
     # Quest Points, Kudos and Combat Points
-    for location_row in location_rows:
-        if location_row.quest_point_reward > 0:
-            item_mapping[f"QP {location_row.quest_point_reward} ({location_row.name})"] = "Quest Point"
-        if location_row.kudos_reward > 0:
-            item_mapping[f"Kudos {location_row.kudos_reward} ({location_row.name})"] = "Kudo"
-        if location_row.combat_point_reward > 0:
-            item_mapping[f"CombatPoints {location_row.combat_point_reward} ({location_row.name})"] = "Combat Point"
+    for location_rows_list in [location_rows, sub_quests]:
+        for location_row in location_rows_list:
+            if location_row.quest_point_reward > 0:
+                item_mapping[f"QP {location_row.quest_point_reward} ({location_row.name})"] = "Quest Point"
+            if location_row.kudos_reward > 0:
+                item_mapping[f"Kudos {location_row.kudos_reward} ({location_row.name})"] = "Kudo"
+            if location_row.combat_point_reward > 0:
+                item_mapping[f"CombatPoints {location_row.combat_point_reward} ({location_row.name})"] = "Combat Point"
 
     return item_mapping
 

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -560,11 +560,11 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                         rand_value = 0 if curr_chance < 0 else self.random.randint(0,max_chance)
                         if rand_value<curr_chance:
                             rand_value = 0 if curr_chance < 0 else self.random.randint(0,max_chance) #Roll the dice again, if we pass this time just demote to useful
+                            base_state.remove(item) #Either it's being removed from the item pool or converted to Useful
                             if rand_value<curr_chance:
                                 itempool.remove(item)
                             else: #This way an item that had a low chance to get removed that got unlucky will probally stay, but dice be dice :)
                                 item.classification = ItemClassification.useful
-                            base_state.remove(item) #Either way it's not a prog item, remove from base_state
                         if rand_value == 0:
                             exit_counter += 1
                             if exit_counter > 5:

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -520,7 +520,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
 
         base_state = CollectionState(self.multiworld)
         for item in itempool:
-            base_state.add_item(item.name,self.player)
+            base_state.collect(item, True)
         temp_state = base_state.copy()
 
 

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -538,6 +538,9 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             raise OptionError("Game isn't beatable with current settings")
 
         if not self.options.disable_chunk_culling:
+            region_loc_count_lookup = {
+                region: len([loc for loc in region.locations if loc.address]) for region in self.get_regions()
+            }
 
             pre_placed_advancements = [loc for loc in self.get_locations() if loc.advancement]
                 
@@ -546,7 +549,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             all_state.sweep_for_advancements(locations=pre_placed_advancements)
             if all_state.stale[self.player]:
                 all_state.update_reachable_regions(self.player)
-            max_chance = len([loc for region in all_state.reachable_regions[self.player] for loc in region.locations if loc.address]) - len(itempool)
+            max_chance = sum([region_loc_count_lookup[region] for region in all_state.reachable_regions[self.player]]) - len(itempool)
             base_itempool = itempool.copy()
             self.random.shuffle(base_itempool)
             exit_counter = 0
@@ -559,7 +562,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
                 if self.multiworld.completion_condition[self.player](temp_state):
                     if temp_state.stale[self.player]:
                         temp_state.update_reachable_regions(self.player)
-                    curr_chance = len([loc for region in temp_state.reachable_regions[self.player] for loc in region.locations if loc.address]) - len(itempool)
+                    curr_chance = sum([region_loc_count_lookup[region] for region in temp_state.reachable_regions[self.player]]) - len(itempool)
                     for item in short_pool:
                         rand_value = 0 if curr_chance < 0 else self.random.randint(0,max_chance)
                         if rand_value<curr_chance:

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -776,12 +776,12 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             if qp_count > 1:
                 state.add_item(item="Quest Point",player=self.player,count=(qp_count-1))
             super().collect(state,self.create_event("Quest Point"))
-        if item.name.startswith("CombatPoints "):
+        elif item.name.startswith("CombatPoints "):
             qp_count = int(item.name.split(" ",3)[1])
             if qp_count > 1:
                 state.add_item(item="Combat Point",player=self.player,count=(qp_count-1))
             super().collect(state,self.create_event("Combat Point"))
-        if item.name.startswith("Kudos "):
+        elif item.name.startswith("Kudos "):
             qp_count = int(item.name.split(" ",3)[1])
             if qp_count > 1:
                 state.add_item(item="Kudo",player=self.player,count=(qp_count-1))
@@ -796,12 +796,12 @@ class OSRSMWorld(CachedRuleBuilderWorld):
             if qp_count > 1:
                 state.remove_item(item="Quest Point",player=self.player,count=(qp_count-1))
             super().remove(state,self.create_event("Quest Point"))
-        if item.name.startswith("CombatPoints "):
+        elif item.name.startswith("CombatPoints "):
             qp_count = int(item.name.split(" ",3)[1])
             if qp_count > 1:
                 state.remove_item(item="Combat Point",player=self.player,count=(qp_count-1))
             super().remove(state,self.create_event("Combat Point"))
-        if item.name.startswith("Kudos "):
+        elif item.name.startswith("Kudos "):
             qp_count = int(item.name.split(" ",3)[1])
             if qp_count > 1:
                 state.remove_item(item="Kudo",player=self.player,count=(qp_count-1))

--- a/worlds/osrsm/__init__.py
+++ b/worlds/osrsm/__init__.py
@@ -48,6 +48,29 @@ class OSRSMWeb(WebWorld):
 base_id = 0x070000
 
 
+def _make_rule_builder_item_mapping() -> dict[str, str]:
+    """Rule Builder's item_mapping allows collected/removed items to tell Rule Builder's caching that they update a
+    particular cached item or pseudo-item that rules may check for."""
+    item_mapping: dict[str, str] = {}
+
+    # Training
+    for skill_name in skill_names:
+        map_from = [f"Training_{skill_name}_{level}" for level in range(1, 100)]
+        map_to = f"Training_{skill_name}"
+        item_mapping.update(dict.fromkeys(map_from, map_to))
+
+    # Quest Points, Kudos and Combat Points
+    for location_row in location_rows:
+        if location_row.quest_point_reward > 0:
+            item_mapping[f"QP {location_row.quest_point_reward} ({location_row.name})"] = "Quest Point"
+        if location_row.kudos_reward > 0:
+            item_mapping[f"Kudos {location_row.kudos_reward} ({location_row.name})"] = "Kudo"
+        if location_row.combat_point_reward > 0:
+            item_mapping[f"CombatPoints {location_row.combat_point_reward} ({location_row.name})"] = "Combat Point"
+
+    return item_mapping
+
+
 class OSRSMWorld(CachedRuleBuilderWorld):
     """
     The best retro fantasy MMORPG on the planet. Old School is RuneScape but… older! This is the open world you know and love, but as it was in 2007.
@@ -72,7 +95,7 @@ class OSRSMWorld(CachedRuleBuilderWorld):
 
     item_name_to_id = {item_rows[i].name: base_id + i for i in range(len(item_rows))}
     location_name_to_id = {location_rows[i].name: base_id + i for i in range(len(location_rows))}
-    item_mapping = {f"Training_{skill_name}_{level}":f"Training_{skill_name}" for level in range(1,100) for skill_name in skill_names}
+    item_mapping = _make_rule_builder_item_mapping()
     item_name_groups = { macro_name: set(item_list) for macro_name, item_list in rollable_chunks.items()}
     location_name_groups = { category : set([location_row.name for location_row in location_rs]) for category, location_rs in location_rows_by_category.items()}
 
@@ -790,21 +813,15 @@ class OSRSMWorld(CachedRuleBuilderWorld):
         if item_type == "quest_point":
             assert isinstance(item, OSRSMQuestPointItem)
             qp_count = item.quest_point_reward
-            if qp_count > 1:
-                state.add_item(item="Quest Point",player=self.player,count=(qp_count-1))
-            super().collect(state,self.create_event("Quest Point"))
+            state.add_item(item="Quest Point",player=self.player,count=qp_count)
         elif item_type == "combat_points":
             assert isinstance(item, OSRSMCombatPointsItem)
             combat_point_reward = item.combat_point_reward
-            if combat_point_reward > 1:
-                state.add_item(item="Combat Point", player=self.player, count=(combat_point_reward - 1))
-            super().collect(state, self.create_event("Combat Point"))
+            state.add_item(item="Combat Point", player=self.player, count=combat_point_reward)
         elif item_type == "kudos":
             assert isinstance(item, OSRSMKudosItem)
             kudos = item.kudos_reward
-            if kudos > 1:
-                state.add_item(item="Kudo",player=self.player,count=(kudos-1))
-            super().collect(state,self.create_event("Kudo"))
+            state.add_item(item="Kudo",player=self.player,count=kudos)
         elif item_type == "training":
             # Assert to help type checking, but keep performance on frozen AP or `-O` command line argument.
             assert isinstance(item, OSRSMTrainingItem)
@@ -828,21 +845,15 @@ class OSRSMWorld(CachedRuleBuilderWorld):
         if item_type == "quest_point":
             assert isinstance(item, OSRSMQuestPointItem)
             qp_count = item.quest_point_reward
-            if qp_count > 1:
-                state.remove_item(item="Quest Point",player=self.player,count=(qp_count-1))
-            super().remove(state,self.create_event("Quest Point"))
+            state.remove_item(item="Quest Point",player=self.player,count=qp_count)
         elif item_type == "combat_points":
             assert isinstance(item, OSRSMCombatPointsItem)
             combat_point_reward = item.combat_point_reward
-            if combat_point_reward > 1:
-                state.remove_item(item="Combat Point",player=self.player,count=(combat_point_reward-1))
-            super().remove(state,self.create_event("Combat Point"))
+            state.remove_item(item="Combat Point",player=self.player,count=combat_point_reward)
         elif item_type == "kudos":
             assert isinstance(item, OSRSMKudosItem)
             kudos = item.kudos_reward
-            if kudos > 1:
-                state.remove_item(item="Kudo",player=self.player,count=(kudos-1))
-            super().remove(state,self.create_event("Kudo"))
+            state.remove_item(item="Kudo",player=self.player,count=kudos)
         elif item_type == "training":
             if state.count(item.name, self.player) == 1:
                 # The last Training event for this level is being removed, so the Max Training psuedo-item may need to


### PR DESCRIPTION
There are a few fixes as the first commits, mostly replacing dangerous behaviour with safer replacements.

Most of the performance improvements are quite small, except the change to reimplement HasTraining to use a pseudo-item with collect/remove overrides.

The overall change in generation duration for me with a template yaml and `python -O .\Generate.py --seed 1 --skip_output` is roughly:
| Version | create_regions/s | total/s |
| --- | --- | --- |
| current | 14.0093 | 94.6018373 |
| PR | 10.2835 | 67.6095162 |
| PR + https://github.com/ArchipelagoMW/Archipelago/pull/5913 | 9.2884 | 51.1886474 |

OSRS takes so long to generate that I don't really want to run lots of generations to get a good average, so these numbers are probably fairly inaccurate, since I only ran 1 generation at each commit.

Each commit, after the first fix commit, results in the same output with the same seed, except the final [Don't create training events above level 99](https://github.com/FarisTheAncient/Archipelago/commit/46ec920533672c44274336c65d9e656488c0218e) commit. I am unsure where/how that final commit is changing the randomness. It's possible there is a bug somewhere, or maybe there is some incrementation of `self.random` or `multiworld.random` that is affected by there being fewer event locations total.

To test the collect/remove behaviour I ran the test in https://github.com/ArchipelagoMW/Archipelago/pull/5223