### PR TITLE
Use the size from the `map_locations` when specified, otherwise fallback on map size.

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -113,7 +113,6 @@
 <ApLocationDeferred>:
     text: "Server:"
     size_hint_x: None
-    size: (app.loc_size, app.loc_size)
     canvas.before:
         PushMatrix:
         Rotate:
@@ -141,7 +140,6 @@
 <ApLocationMixed>:
     text: "Server:"
     size_hint_x: None
-    size: (app.loc_size, app.loc_size)
     canvas:
         Color:
             rgb: 0,0,0 
@@ -157,7 +155,6 @@
 <ApLocationSplit>:
     text: "Server:"
     size_hint_x: None
-    size: (app.loc_size, app.loc_size)
     color_2: (1, 0, 0)
     color_4: (1, 1, 0)
     color_1: (0, 1, 0)

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -42,23 +42,23 @@ def get_ut_color(color: str)->str:
     from kivy.properties import StringProperty
     class UTTextColor(Widget):
         in_logic: ClassVar[str] = StringProperty("")
-        glitched: ClassVar[str] = StringProperty("") 
-        out_of_logic: ClassVar[str] = StringProperty("") 
-        collected: ClassVar[str] = StringProperty("") 
-        in_logic_glitched: ClassVar[str] = StringProperty("") 
-        out_of_logic_glitched: ClassVar[str] = StringProperty("") 
-        mixed_logic: ClassVar[str] = StringProperty("") 
-        collected_light: ClassVar[str] = StringProperty("") 
-        hinted: ClassVar[str] = StringProperty("") 
-        hinted_in_logic: ClassVar[str] = StringProperty("") 
-        hinted_out_of_logic: ClassVar[str] = StringProperty("") 
-        hinted_glitched: ClassVar[str] = StringProperty("") 
+        glitched: ClassVar[str] = StringProperty("")
+        out_of_logic: ClassVar[str] = StringProperty("")
+        collected: ClassVar[str] = StringProperty("")
+        in_logic_glitched: ClassVar[str] = StringProperty("")
+        out_of_logic_glitched: ClassVar[str] = StringProperty("")
+        mixed_logic: ClassVar[str] = StringProperty("")
+        collected_light: ClassVar[str] = StringProperty("")
+        hinted: ClassVar[str] = StringProperty("")
+        hinted_in_logic: ClassVar[str] = StringProperty("")
+        hinted_out_of_logic: ClassVar[str] = StringProperty("")
+        hinted_glitched: ClassVar[str] = StringProperty("")
         excluded: ClassVar[str] = StringProperty("")
         unconnected: ClassVar[str] = StringProperty("")
     if not hasattr(get_ut_color,"utTextColor"):
         get_ut_color.utTextColor = UTTextColor()
     return str(getattr(get_ut_color.utTextColor,color,"DD00FF"))
-    
+
 class TrackerCommandProcessor(ClientCommandProcessor):
     ctx: "TrackerGameContext"
 
@@ -232,7 +232,7 @@ class TrackerCommandProcessor(ClientCommandProcessor):
         if self.ctx.ui:
             self.ctx.ui.last_autofillable_command = "/get_logical_path"
         get_logical_path(self.ctx, dest_name)
-    
+
     @mark_raw
     def _cmd_explain(self,lookup_name:str=""):
         """Explains the rule for a location, if the world supports it"""
@@ -412,7 +412,7 @@ class TrackerGameContext(CommonContext):
                 relevent_coords = self.coord_dict.get(location, [])
                 if not relevent_coords:
                     continue
-                
+
                 if location in self.checked_locations or location in self.tracker_core.ignored_locations:
                     status = "collected"
                 elif location in self.tracker_core.locations_available:
@@ -685,10 +685,11 @@ class TrackerGameContext(CommonContext):
                 temp_locs.extend(temp_loc["children"])
         coords = {
             (map_loc["x"], map_loc["y"]):
-                [location_name_to_id[section["name"]] for section in location["sections"]
-                    if "name" in section and section["name"] in location_name_to_id
-                    and location_name_to_id[section["name"]] in self.server_locations
-                    and not location_name_to_id[section["name"]] in current_hidden_locs]
+                ([location_name_to_id[section["name"]] for section in location["sections"]
+                  if "name" in section and section["name"] in location_name_to_id
+                  and location_name_to_id[section["name"]] in self.server_locations
+                  and not location_name_to_id[section["name"]] in current_hidden_locs],
+                 map_loc.get("size"))
             for location in map_locs
             for map_loc in location["map_locations"]
             if map_loc["map"] == m["name"] and any(
@@ -702,10 +703,11 @@ class TrackerGameContext(CommonContext):
         if poptracker_name_mapping:
             tempCoords = {  # compat coords
                 (map_loc["x"], map_loc["y"]):
-                    [poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] for section in location["sections"]
-                        if "name" in section and f'{location["name"]}/{section["name"]}' in poptracker_name_mapping
-                        and poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] in self.server_locations
-                        and poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] not in current_hidden_locs]
+                    ([poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] for section in location["sections"]
+                      if "name" in section and f'{location["name"]}/{section["name"]}' in poptracker_name_mapping
+                      and poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] in self.server_locations
+                      and poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] not in current_hidden_locs],
+                     map_loc.get("size"))
                 for location in map_locs
                 for map_loc in location["map_locations"]
                 if map_loc["map"] == m["name"]
@@ -714,18 +716,19 @@ class TrackerGameContext(CommonContext):
                            and poptracker_name_mapping[f'{location["name"]}/{section["name"]}'] not in current_hidden_locs
                            for section in location["sections"])
             }
-            for maploc, seclist in tempCoords.items():
+            for maploc, (seclist, size) in tempCoords.items():
                 if maploc in coords:
-                    coords[maploc] += seclist
+                    coords[maploc] = (coords[maploc][0] + seclist, coords[maploc][1] or size)
                 else:
-                    coords[maploc] = seclist
+                    coords[maploc] = (seclist, size)
         entrance_cache = list(self.tracker_core.multiworld.regions.entrance_cache[self.tracker_core.player_id].keys())
         hidden_entrances = getattr(self.tracker_core.get_current_world(), "ut_map_page_hidden_entrances", {})
         current_hidden_entrances = hidden_entrances.get(m["name"], [])
         dcoords = {
-            (map_loc["x"], map_loc["y"]): [section["name"] for section in location["sections"]
-                if "name" in section and section["name"] in entrance_cache
-                and section["name"] not in current_hidden_entrances]
+            (map_loc["x"], map_loc["y"]): ([section["name"] for section in location["sections"]
+                                            if "name" in section and section["name"] in entrance_cache
+                                            and section["name"] not in current_hidden_entrances],
+                                           map_loc.get("size"))
             for location in map_locs
             for map_loc in location["map_locations"]
             if map_loc["map"] == m["name"] and any(
@@ -736,10 +739,11 @@ class TrackerGameContext(CommonContext):
         poptracker_entrance_mapping = self.tracker_world.poptracker_entrance_mapping
         if poptracker_entrance_mapping:
             tempCoords = {
-                (map_loc["x"], map_loc["y"]): [poptracker_entrance_mapping[section["name"]] for section in location["sections"]
-                    if "name" in section and section["name"] in poptracker_entrance_mapping
-                    and poptracker_entrance_mapping[section["name"]] in entrance_cache
-                    and poptracker_entrance_mapping[section["name"]] not in current_hidden_entrances]
+                (map_loc["x"], map_loc["y"]): ([poptracker_entrance_mapping[section["name"]] for section in location["sections"]
+                                                if "name" in section and section["name"] in poptracker_entrance_mapping
+                                                and poptracker_entrance_mapping[section["name"]] in entrance_cache
+                                                and poptracker_entrance_mapping[section["name"]] not in current_hidden_entrances],
+                                               map_loc.get("size"))
                 for location in map_locs
                 for map_loc in location["map_locations"]
                 if map_loc["map"] == m["name"] and any(
@@ -749,16 +753,18 @@ class TrackerGameContext(CommonContext):
                     for section in location["sections"]
                 )
             }
-            for maploc, seclist in tempCoords.items():
+            for maploc, (seclist, size) in tempCoords.items():
                 if maploc in dcoords:
-                    dcoords[maploc] += seclist
+                    dcoords[maploc] = (dcoords[maploc][0] + seclist, dcoords[maploc][1] or size)
                 else:
-                    dcoords[maploc] = seclist
+                    dcoords[maploc] = (seclist, size)
         event_loc_cache = [loc.name for loc in self.tracker_core.get_current_world().get_locations() if loc.address is None and loc.parent_region is not None]
         hidden_events = getattr(self.tracker_core.get_current_world(), "ut_map_page_hidden_events", {})
         current_hidden_events = hidden_events.get(m["name"], [])
         dlcoords = {
-            (map_loc["x"], map_loc["y"]): [section["name"] for section in location["sections"] if "name" in section and section["name"] in event_loc_cache and section["name"] not in current_hidden_events]
+            (map_loc["x"], map_loc["y"]): ([section["name"] for section in location["sections"] if
+                                            "name" in section and section["name"] in event_loc_cache and section["name"] not in current_hidden_events],
+                                           map_loc.get("size"))
             for location in map_locs
             for map_loc in location["map_locations"]
             if map_loc["map"] == m["name"] and any(
@@ -769,16 +775,16 @@ class TrackerGameContext(CommonContext):
         }
         both_dcoords = set(entrance_cache).intersection(set(event_loc_cache))
         if both_dcoords:
-            for _,temp_coord in dcoords.items():
-                if both_dcoords.intersection(set(temp_coord)):
+            for _, (temp_names, _) in dcoords.items():
+                if both_dcoords.intersection(temp_names):
                     logger.error("Mixing of entrance and event names, map will refuse to load")
                     return
-            for _,temp_coord in dlcoords.items():
-                if both_dcoords.intersection(set(temp_coord)):
+            for _, (temp_names, _) in dlcoords.items():
+                if both_dcoords.intersection(temp_names):
                     logger.error("Mixing of entrance and event names, map will refuse to load")
                     return
         self.coord_dict, self.deferred_dict, self.ldeferred_dict = self.map_page_coords_func(coords, dcoords, dlcoords,
-                                                                                             self.use_split)
+                                                                                             self.use_split, self.ui.loc_size)
         if self.tracker_world.location_setting_key:
             self.update_location_icon_coords()
 
@@ -825,7 +831,7 @@ class TrackerGameContext(CommonContext):
 
         class TrackerTooltip(ToolTip):
             pass
-    
+
         class TrackerView(MDRecycleView):
             def __init__(self, **kwargs):
                 super().__init__(**kwargs)
@@ -855,14 +861,14 @@ class TrackerGameContext(CommonContext):
                 super().__init__(**kwargs)
                 self._tooltip = TrackerTooltip(text="Test")
                 self._tooltip.markup = True
-            
+
             def on_enter(self):
                 self._tooltip.text = self.get_text()
                 self.display_tooltip()
 
             def on_leave(self):
                 self.animation_tooltip_dismiss()
-            
+
             def transform_to_pop_coords(self,x,y):
                 x2 = (x)
                 y2 = (self.tracker_page.height - y)
@@ -873,7 +879,7 @@ class TrackerGameContext(CommonContext):
                 x5 = x4 + self.width/2
                 y5 = y4 + self.width/2
                 return (x5,y5)
-            
+
             def on_mouse_pos(self, window, pos): #this does nothing, but it's kept here to make adding debug prints easier
                 return super().on_mouse_pos(window, pos)
 
@@ -882,7 +888,7 @@ class TrackerGameContext(CommonContext):
                     return self.border_point
                 else:
                     return self.tracker_page.to_window(x,y)
-            
+
             def to_widget(self, x, y):
                 return self.transform_to_pop_coords(*self.tracker_page.to_widget(x,y))
 
@@ -890,7 +896,7 @@ class TrackerGameContext(CommonContext):
                 if location in self.locationDict:
                     if self.locationDict[location] != status:
                         self.locationDict[location] = status
-            
+
             def get_text(self):
                 ctx = manager.get_running_app().ctx
                 location_id_to_name = AutoWorld.AutoWorldRegister.world_types[ctx.game].location_id_to_name
@@ -899,12 +905,12 @@ class TrackerGameContext(CommonContext):
                     color = get_ut_color("collected_light")
                     if status in ["in_logic","out_of_logic","glitched","hinted_in_logic","hinted_out_of_logic","hinted_glitched"]:
                         color = get_ut_color(status)
-                    sReturn.append(f"{location_id_to_name[loc]} : [color={color}]{status}[/color]") 
+                    sReturn.append(f"{location_id_to_name[loc]} : [color={color}]{status}[/color]")
                 return "\n".join(sReturn)
 
             def update_color(self, locationDict):
                 return
-            
+
         class ApLocationDeferred(ApLocation):
             from kivy.properties import ColorProperty
             color = ColorProperty("#"+get_ut_color("error"))
@@ -922,7 +928,7 @@ class TrackerGameContext(CommonContext):
                     self.color = "#"+get_ut_color("out_of_logic")
                 else:
                     self.color = "#"+get_ut_color("collected")
-            
+
             def get_text(self):
                 ctx = manager.get_running_app().ctx
                 host_world:AutoWorld.World = ctx.tracker_core.get_current_world()
@@ -949,7 +955,7 @@ class TrackerGameContext(CommonContext):
                                 sReturn.append(f" - connects to ({real_entrance.connected_region.name})")
                 return "\n".join(sReturn)
 
-            
+
         class APLocationMixed(ApLocation):
             from kivy.properties import ColorProperty
             color = ColorProperty("#"+get_ut_color("error"))
@@ -1025,26 +1031,31 @@ class TrackerGameContext(CommonContext):
 
         class VisualTracker(BoxLayout):
             location_icon: ApLocationIcon
-            def load_coords(self,  coords: dict[tuple,list[int]], defered_coords: dict[tuple, list[str]],
-                             ldefered_coords: dict[tuple, list[str]], use_split) -> tuple[dict[int,list], dict[str,list], dict[str,list]]:
+
+            def load_coords(self, coords: dict[tuple, tuple[list[int], int | None]], defered_coords: dict[tuple, tuple[list[str], int | None]],
+                            ldefered_coords: dict[tuple, tuple[list[str], int | None]], use_split, default_loc_size: int = 65) \
+                    -> tuple[dict[int, list], dict[str, list], dict[str, list]]:
                 self.ids.location_canvas.clear_widgets()
-                returnDict: dict[int,list] = defaultdict(list)
-                deferredDict: dict[str,list] = defaultdict(list)
-                ldeferredDict: dict[str,list] = defaultdict(list)
-                for coord, sections in coords.items():
+                returnDict: dict[int, list] = defaultdict(list)
+                deferredDict: dict[str, list] = defaultdict(list)
+                ldeferredDict: dict[str, list] = defaultdict(list)
+                for coord, (sections, size) in coords.items():
                     # https://discord.com/channels/731205301247803413/1170094879142051912/1272327822630977727
                     ap_location_class = APLocationSplit if use_split else APLocationMixed
-                    temp_loc = ap_location_class(sections, self.ids.tracker_map, pos=(coord))
+                    loc_size = size if size is not None else default_loc_size
+                    temp_loc = ap_location_class(sections, self.ids.tracker_map, pos=coord, size=(loc_size, loc_size))
                     self.ids.location_canvas.add_widget(temp_loc)
                     for location_id in sections:
                         returnDict[location_id].append(temp_loc)
-                for coord, sections in defered_coords.items():
-                    temp_loc = ApLocationDeferred(sections, self.ids.tracker_map, True, pos=(coord))
+                for coord, (sections, size) in defered_coords.items():
+                    loc_size = size if size is not None else default_loc_size
+                    temp_loc = ApLocationDeferred(sections, self.ids.tracker_map, True, pos=coord, size=(loc_size, loc_size))
                     self.ids.location_canvas.add_widget(temp_loc)
                     for entrance_name in sections:
                         deferredDict[entrance_name].append(temp_loc)
-                for coord, sections in ldefered_coords.items():
-                    temp_loc = ApLocationDeferred(sections, self.ids.tracker_map, False, pos=(coord))
+                for coord, (sections, size) in ldefered_coords.items():
+                    loc_size = size if size is not None else default_loc_size
+                    temp_loc = ApLocationDeferred(sections, self.ids.tracker_map, False, pos=coord, size=(loc_size, loc_size))
                     self.ids.location_canvas.add_widget(temp_loc)
                     for event_name in sections:
                         ldeferredDict[event_name].append(temp_loc)
@@ -1341,7 +1352,7 @@ class TrackerGameContext(CommonContext):
                     self.updateTracker()
                 else:
                     asyncio.create_task(wait_for_items(self),name="UT Delay function") #if we don't get new items, delay for a bit first
-                self.watcher_task = asyncio.create_task(game_watcher(self), name="GameWatcher") #This shouldn't be needed, but technically 
+                self.watcher_task = asyncio.create_task(game_watcher(self), name="GameWatcher") #This shouldn't be needed, but technically
             elif cmd == 'RoomUpdate':
                 if not (self.items_handling & 0b010):
                     self.scout_checked_locations()
@@ -1375,7 +1386,7 @@ class TrackerGameContext(CommonContext):
                              "Then try to reproduce with the debug launcher and post in the Discord channel")
             self.disconnected_intentionally = True
             raise e
-        
+
     def update_location_icon_coords(self):
         icon_key = self.tracker_world.location_setting_key
         temp_ret = self.tracker_world.location_icon_coords(self.map_id,self.stored_data.get(icon_key, ""))
@@ -1464,7 +1475,7 @@ def explain_more(ctx: TrackerGameContext, argument: str):
             return
         logger.info("Nothing to explain")
     logger.error("Current world to track doesn't support command /explain_more")
-    
+
 
 def explain(ctx: TrackerGameContext, dest_name: str):
     from NetUtils import JSONMessagePart
@@ -1522,7 +1533,7 @@ def explain(ctx: TrackerGameContext, dest_name: str):
                     ctx.ui.print_json(returned_json)
                 else:
                     ctx.ui.print_json([{"type":"text","text":f"{entrance.parent_region.name} ({entrance.parent_region.can_reach(state)}): {entrance.name} : {entrance.access_rule(state)}"}])
-        
+
 
 def get_logical_path(ctx: TrackerGameContext, dest_name: str):
     if ctx.tracker_core.player_id is None or ctx.tracker_core.multiworld is None:


### PR DESCRIPTION
## What is this fixing or adding?

So I was working on adding the pop tracker from The Messenger to UT while I'm blocked in an async, and I noticed the locations are way too small to see... This uses the size specified in the `map_locations`. Some maps utilize different size for their locations, and it looks bad without it. 

I tried to make PyCharm not reformat anything, but it insisted on removing trailing spaces... 

## How was this tested?
See below

## If this makes graphical changes, please attach screenshots.

<details><summary>Before</summary>
<p>

<img width="1208" height="695" alt="image" src="https://github.com/user-attachments/assets/b8b0c540-21a9-4c7c-b0ba-a966295c6081" />

<img width="1219" height="651" alt="image" src="https://github.com/user-attachments/assets/190cb62c-510e-4002-847f-8adf390c6fd3" />

</p>
</details> 


<details><summary>After</summary>
<p>

<img width="1226" height="740" alt="image" src="https://github.com/user-attachments/assets/ea7ee3f0-77d9-4e33-afc9-d65d5f318f54" />

<img width="1224" height="686" alt="image" src="https://github.com/user-attachments/assets/b0e4b838-7474-406c-992d-fe0899498305" />

</p>
</details> 

