### PR TITLE
Move location setting to avoid losing items from state

### DIFF
--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -316,14 +316,14 @@ class TrackerCore():
         for item_name, item_flags, item_loc, item_player in [(item_id_to_name[item.item],item.flags,item.location, item.player) for item in self.tracker_items_received if item.item > 0] + [(name,ItemClassification.progression,-1,-1) for name in self.manual_items]:
             try:
                 world_item = self.multiworld.create_item(item_name, self.player_id)
-                if item_loc>0 and item_player == self.slot and item_loc in location_id_to_name:
-                    world_item.location = self.multiworld.get_location(location_id_to_name[item_loc],self.player_id)
                 world_item.classification = world_item.classification | item_flags
                 state.collect(world_item, True)
                 if world_item.advancement:
                     prog_items[world_item.name] += 1
                 if world_item.code is not None:
                     all_items[world_item.name] += 1
+                if item_loc>0 and item_player == self.slot and item_loc in location_id_to_name:
+                    world_item.location = self.multiworld.get_location(location_id_to_name[item_loc],self.player_id)
             except Exception:
                 self.log_to_tab("Item id " + str(item_name) + " not able to be created", False)
         state.sweep_for_advancements(


### PR DESCRIPTION
## What is this fixing or adding?
When attempting to set a location for an item found locally in TrackerCore, if that location can't be found, the item won't get added to UT's state or inventory while the error message is quietly erased. This causes weird bugs where items exist in `/received` but don't in `/inventory` or `/prog_inventory`. While failing to find the location is a world bug that needs to be addressed, we can avoid the item disappearing from the state/inventory by simply trying to set the location after the item is added to state/inventory.

## How was this tested?
Tested against a misbehaving world (before fixing it) to confirm the items in question were now found in `/inventory`.
