### PR TITLE
Improve item creation error logging

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -88,6 +88,7 @@
     hinted_glitched:"ff9f20"
     excluded: "CFCFCF"
     unconnected: "89F336"
+    error: "FF0000"
 <ApAsyncImage>:
 
 <ApLocationIcon>:

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -55,6 +55,7 @@ def get_ut_color(color: str)->str:
         hinted_glitched: ClassVar[str] = StringProperty("") 
         excluded: ClassVar[str] = StringProperty("")
         unconnected: ClassVar[str] = StringProperty("")
+        error: ClassVar[str] = StringProperty("")
     if not hasattr(get_ut_color,"utTextColor"):
         get_ut_color.utTextColor = UTTextColor()
     return str(getattr(get_ut_color.utTextColor,color,"DD00FF"))

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -327,7 +327,7 @@ class TrackerCore():
                 if world_item.code is not None:
                     all_items[world_item.name] += 1
             except Exception:
-                self.log_to_tab("[color="+self.get_ut_color("error")+"]Item id " + str(item_name) + " not able to be created", False)
+                self.log_to_tab("[color="+self.get_ut_color("error")+"]Item id " + str(item_name) + " not able to be created[/color]", False)
         state.sweep_for_advancements(
             locations=[location for location in self.multiworld.get_locations(self.player_id) if (not location.address)])
 

--- a/worlds/tracker/TrackerCore.py
+++ b/worlds/tracker/TrackerCore.py
@@ -313,6 +313,8 @@ class TrackerCore():
             self.logger.error("The Following items are unknown [" + ",".join(invalid_items)+"]")
             raise Exception("Your datapackage is incorrect, please correct the apworld for "+str(self.game))
 
+        self.clear_page()
+
         for item_name, item_flags, item_loc, item_player in [(item_id_to_name[item.item],item.flags,item.location, item.player) for item in self.tracker_items_received if item.item > 0] + [(name,ItemClassification.progression,-1,-1) for name in self.manual_items]:
             try:
                 world_item = self.multiworld.create_item(item_name, self.player_id)
@@ -325,11 +327,10 @@ class TrackerCore():
                 if world_item.code is not None:
                     all_items[world_item.name] += 1
             except Exception:
-                self.log_to_tab("Item id " + str(item_name) + " not able to be created", False)
+                self.log_to_tab("[color="+self.get_ut_color("error")+"]Item id " + str(item_name) + " not able to be created", False)
         state.sweep_for_advancements(
             locations=[location for location in self.multiworld.get_locations(self.player_id) if (not location.address)])
 
-        self.clear_page()
         regions = []
         locations = []
         readable_locations = []


### PR DESCRIPTION
## What is this fixing or adding?
This moves the call to self.clear_page() in TrackerCore.py so that error logs from creating items aren't immediately cleared, so they can actually be displayed. Additionally, it gives errors a unique color (red (FF0000) by default).

## How was this tested?
By using a world with known datapackage mismatches with certain locations,

## If this makes graphical changes, please attach screenshots.
<img width="805" height="634" alt="image" src="https://github.com/user-attachments/assets/9bc8f665-e13f-4e49-b8a4-52b770a2319b" />
