### PR TITLE
Fix fuzzer hook not converting slot_data through json

### DIFF
--- a/worlds/tracker/fuzzer_hook.py
+++ b/worlds/tracker/fuzzer_hook.py
@@ -2,6 +2,7 @@ from fuzz import BaseHook, GenOutcome
 from typing import List, Dict, Set
 import collections
 import logging
+import json
 from . import TrackerCore, DeferredEntranceMode
 from BaseClasses import MultiWorld,Location,ItemClassification
 from NetUtils import NetworkItem
@@ -39,6 +40,8 @@ class Hook(BaseHook):
         temp = Context.decompress(data)
 
         slot_data = temp["slot_data"][1] #slot 0 is reserved
+        # slot_data is sent to clients as json, so pass the slot_data through json conversion to ensure slot_data is uses the correct types.
+        slot_data = json.loads(json.dumps(slot_data))
 
         self.ut_core.set_slot_params(mw.worlds[1].game,1,mw.player_name[1],1)
         self.ut_core.initalize_tracker_core(mw.worlds[1].__class__,slot_data)

--- a/worlds/tracker/fuzzer_hook.py
+++ b/worlds/tracker/fuzzer_hook.py
@@ -40,7 +40,7 @@ class Hook(BaseHook):
         temp = Context.decompress(data)
 
         slot_data = temp["slot_data"][1] #slot 0 is reserved
-        # slot_data is sent to clients as json, so pass the slot_data through json conversion to ensure slot_data is uses the correct types.
+        # slot_data is sent to clients as json, so pass the slot_data through json conversion to ensure slot_data uses the correct types.
         slot_data = json.loads(json.dumps(slot_data))
 
         self.ut_core.set_slot_params(mw.worlds[1].game,1,mw.player_name[1],1)


### PR DESCRIPTION
## What is this fixing or adding?

The fuzzer hook was passing the raw slot_data from the multidata directly to the UT passthrough.

This caused issues because AP converts tuple/list/set/frozenset values in slot_data into tuples before writing them into the multidata (see `NetUtils.convert_to_base_types()`), but when this data is dumped to json, sent to clients, and then loaded from json by clients, any tuples in the original slot_data will have become lists, so an apworld with UT support, expecting the slot_data to contain lists, could crash with the fuzzer hook because the slot_data would instead contain tuples.

The slot_data is now dumped to json and then loaded from json, so emulate the conversion that would happen when the slot_data is sent from the server to the client.

## How was this tested?

I ran the fuzzer hook with the pre-release of the Lego Star Wars TCS apworld, whose UT support calls `.copy()` on one of the lists received from slot_data, which would crash when running with the fuzzer hook because, when running with the hook, the lists would actually be tuples, which do not have a `.copy()` method.