### PR TITLE
Default generation outcome to `OptionError` to ignore gen issues

### DIFF
--- a/worlds/tracker/fuzzer_hook.py
+++ b/worlds/tracker/fuzzer_hook.py
@@ -21,6 +21,9 @@ class Hook(BaseHook):
         self.ut_core.run_generator(None,None,args.player_files_path) #initial UT gen
 
     def after_generate(self, mw:MultiWorld, output_path):
+        # Default to OptionError in case generation failed or is invalid, so
+        # that it gets marked as ignored as we're not testing for that
+        self.status = GenOutcome.OptionError
         if mw is None:
             return
         if len(mw.worlds)>1:


### PR DESCRIPTION
When running the hook I'm expecting failures to be UT failures and not generation issues. Keeping generation issues as actual failures makes triaging a bit painful because we cannot rely on numbers alone but have to check whether the failure is a problem with generation (and given this only supports one world, it's fairly common to have restrictive start gen failures with apworlds that are prone to that) or if it's something actionable