### PR TITLE
Support for multiple player icons

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -96,7 +96,6 @@
 
 <ApLocationIcon>:
     id: location_icon
-    source: app.iconSource
     size: (0,0)
     pos_hint: {'center_x': 0.5, 'center_y': 0.5}
     canvas.before:

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -382,7 +382,7 @@ class TrackerGameContext(CommonContext):
         self.quit_after_update = print_list or print_count
         self.print_list = print_list
         self.print_count = print_count
-        self.location_icon = None
+        self.location_icons = []
         self.root_pack_path = None
         self.map_id = None
         self.defered_entrance_datastorage_keys = []
@@ -1049,7 +1049,7 @@ class TrackerGameContext(CommonContext):
                     self.color_4="#"+get_ut_color("collected")
 
         class VisualTracker(BoxLayout):
-            location_icon: ApLocationIcon
+            location_icons: list[ApLocationIcon]
 
             def load_coords(self, coords: dict[tuple, tuple[list[int], int | None]], defered_coords: dict[tuple, tuple[list[str], int | None]],
                             ldefered_coords: dict[tuple, tuple[list[str], int | None]], use_split, default_loc_size: int = 65) \
@@ -1078,9 +1078,26 @@ class TrackerGameContext(CommonContext):
                     self.ids.location_canvas.add_widget(temp_loc)
                     for event_name in sections:
                         ldeferredDict[event_name].append(temp_loc)
-                self.ids.location_canvas.add_widget(self.location_icon)
+                self.location_icons = []
                 return returnDict, deferredDict, ldeferredDict
 
+            def update_location_icon_widgets(self, ctx: TrackerGameContext, location_icons: list[tuple[int, int, str]]):
+                #I could just clear all icon widgets and recreate them every time one changes, probably not a big performance loss tbh,
+                #but reusing the existing widgets on changes and only adding/removing when necessary seems like the more proper way
+
+                for i, (x, y, ref) in enumerate(location_icons):
+                    if i < len(self.location_icons):
+                        self.location_icons[i].source = f"{ctx.root_pack_path}/{ref}"
+                        self.location_icons[i].pos = (x, y)
+                    else:
+                        location_icon = ApLocationIcon(source=f"{ctx.root_pack_path}/{ref}", pos=(x, y), size=(ctx.ui.loc_icon_size, ctx.ui.loc_icon_size))
+                        self.ids.location_canvas.add_widget(location_icon)
+                        self.location_icons.append(location_icon)
+
+                if len(self.location_icons) > len(location_icons):
+                    for icon in self.location_icons[len(location_icons):]:
+                        self.ids.location_canvas.remove_widget(icon)
+                    del self.location_icons[len(location_icons):]
 
         try:
             tracker = TrackerLayout(orientation="vertical")
@@ -1109,10 +1126,9 @@ class TrackerGameContext(CommonContext):
             tracker.add_widget(tracker_view)
 
             self.tracker_page = tracker_view
-            self.location_icon = ApLocationIcon()
+            self.location_icons = []
 
             map_content = VisualTracker()
-            map_content.location_icon = self.location_icon
             self.map_page_coords_func = map_content.load_coords
             if self.gen_error is not None:
                 for line in self.gen_error.split("\n"):
@@ -1129,6 +1145,7 @@ class TrackerGameContext(CommonContext):
             if value:
                 if not test:
                     test.append(self.add_client_tab("Map Page", map_content))
+                    self.ctx.map_page = map_content
             else:
                 if test:
                     map_tab = test.pop()
@@ -1156,7 +1173,6 @@ class TrackerGameContext(CommonContext):
             loc_icon_size = NumericProperty(20)
             loc_border = NumericProperty(5)
             enable_map = BooleanProperty(False)
-            iconSource = StringProperty("")
             current_map = StringProperty("")
             auto_tab = BooleanProperty(True)
             base_title = f"Tracker {UT_VERSION} for AP version"  # core appends ap version so this works
@@ -1413,15 +1429,19 @@ class TrackerGameContext(CommonContext):
 
     def update_location_icon_coords(self):
         icon_key = self.tracker_world.location_setting_key
-        temp_ret = self.tracker_world.location_icon_coords(self.map_id,self.stored_data.get(icon_key, ""))
-        if temp_ret:
-            (x,y,ref) = temp_ret #should be a 3-tuple
-            if x < 0 or y < 0:
-                self.location_icon.size = (0,0)
-            else:
-                self.ui.iconSource = f"{self.root_pack_path}/{ref}"
-                self.location_icon.size = (self.ui.loc_icon_size, self.ui.loc_icon_size)
-                self.location_icon.pos = (x,y)
+        temp_rets = self.tracker_world.location_icon_coords(self.map_id,self.stored_data.get(icon_key, ""))
+
+        self.location_icons.clear()
+        if temp_rets:
+            if type(temp_rets) != list: #If it's the old callback that just returns a single tuple, we just put it in a single item list
+                temp_rets = [temp_rets]
+            for temp_ret in temp_rets:
+                (x,y,ref) = temp_ret #should be a 3-tuple
+                if x >= 0 and y >= 0:
+                    self.location_icons.append((x,y,ref))
+        if self.map_page:
+            self.map_page.update_location_icon_widgets(self, self.location_icons)
+            
 
     def update_defered_entrances(self, keys: list[str]):
         if self.defered_entrance_callback and keys:

--- a/worlds/tracker/__init__.py
+++ b/worlds/tracker/__init__.py
@@ -164,7 +164,7 @@ class UTMapTabData:
     location_setting_key: str
     """Data storage key used to determine where to place the location indicator"""
 
-    location_icon_coords: Callable[[int, Any], tuple[int,int,str]|None]
+    location_icon_coords: Callable[[int, Any], tuple[int,int,str]|list[tuple[int,int,str]]|None]
     """Function used to convert between the map and the value in data storage into coords (or none to hide it) the return is [x, y, override path string]"""
 
     def __init__(


### PR DESCRIPTION
## What is this fixing or adding?
Adding the possibility for apworlds to display multiple player icons on the map tracker via the _location_icon_coords_ callback. Useful when multiple people play on the same slot.

## How was this tested?
Created a mock-apworld with a _location_icon_coords_ function that returns a list of position tuples instead of a single position tuple.
Also tested if the old syntax still works and still shows a singular icon so current apworlds using this don't break.