### PR TITLE
Add zoom and pan to map tracker

### DIFF
--- a/worlds/tracker/Tracker.kv
+++ b/worlds/tracker/Tracker.kv
@@ -34,44 +34,67 @@
             pos_hint: {'center_x': 0.5}
             size_hint: None, None
             size: self.minimum_size
+            padding: [12,8]
+            spacing: 16
             CheckItem:
                 id: auto_tab_checkitem
                 text: "Auto Tab"
                 active: app.auto_tab
+                pos_hint: {'center_y': 0.5}
                 on_active: app.on_auto_tab_active(*args)
-                padding: [20, 0]
             MDDropDownItem:
                 id: map_list
                 on_release: app.open_map_dropdown(self)
                 MDDropDownItemText:
                     id: drop_text
                     text: "Current Map: " + app.current_map
-        ApAsyncImage:
-            id: tracker_map
-            source: app.source
-            fit_mode: "contain"
-        Widget:
-            id: location_canvas
-            pos_hint: {'center_x': 0.5, 'center_y': 0.5}
-            size_hint: '0.01dp', '0.02dp'
-            canvas.before:
-                PushMatrix:
-                Rotate:
-                    #make top left 0,0 like poptracker
-                    origin: tracker_map.center
-                    angle: 180
-                    axis: 1, 0, 0
-                Translate:
-                    #scale location_canvas with tracker_map to match resizing
-                    xy: (tracker_map.x + (tracker_map.width - tracker_map.norm_image_size[0])/2, tracker_map.y + (tracker_map.height - tracker_map.norm_image_size[1])/2)
-                Scale:
-                    #scale coords by original size so we can use coords for full image
-                    origin: 0,0
-                    x: tracker_map.norm_image_size[0] / tracker_map.texture_size[0] if tracker_map.texture_size[0] > 0 else 1
-                    y: tracker_map.norm_image_size[1] / tracker_map.texture_size[1] if tracker_map.texture_size[1] > 0 else 1
-            canvas.after:
-                #close transformations in after canvas so all objects get transformed
-                PopMatrix:
+            MDButton:
+                style: "outlined"
+                size_hint: None, None
+                height: dp(32)
+                pos_hint: {'center_y': 0.5}
+                radius: [dp(4),dp(4),dp(4),dp(4)]
+                on_release: tracker_map_container.recenter_view()
+                MDButtonText:
+                    text: "Recenter"
+                    font_style: "Label"
+                    role: "medium"
+
+        BoxStencil:
+            ScrollWheelZoomScatterLayout:
+                id: tracker_map_container
+                do_rotation: False
+                auto_bring_to_front: False
+                scale_min: 0.2
+                scale_max: 20.0
+                
+                ApAsyncImage:
+                    id: tracker_map
+                    source: app.source
+                    fit_mode: "contain"
+                    pos_hint: {'x': 0, 'y': 0}
+
+                Widget:
+                    id: location_canvas
+                    pos_hint: {'x': 0, 'y': 0}
+                    canvas.before:
+                        PushMatrix:
+                        Rotate:
+                            #make top left 0,0 like poptracker
+                            origin: tracker_map.center
+                            angle: 180
+                            axis: 1, 0, 0
+                        Translate:
+                            #scale location_canvas with tracker_map to match resizing
+                            xy: (tracker_map.x + (tracker_map.width - tracker_map.norm_image_size[0])/2, tracker_map.y + (tracker_map.height - tracker_map.norm_image_size[1])/2)
+                        Scale:
+                            #scale coords by original size so we can use coords for full image
+                            origin: 0,0
+                            x: tracker_map.norm_image_size[0] / tracker_map.texture_size[0] if tracker_map.texture_size[0] > 0 else 1
+                            y: tracker_map.norm_image_size[1] / tracker_map.texture_size[1] if tracker_map.texture_size[1] > 0 else 1
+                    canvas.after:
+                        #close transformations in after canvas so all objects get transformed
+                        PopMatrix:
 
 <UTTextColor>:
     in_logic: "20ff20"

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -852,10 +852,52 @@ class TrackerGameContext(CommonContext):
         from kvui import MDRecycleView, HoverBehavior, MDLabel, MDDivider
         from kivymd.uix.tooltip import MDTooltip
         from kivy.uix.widget import Widget
+        from kivy.uix.scatterlayout import ScatterLayout
+        from kivy.uix.stencilview import StencilView
+        from kivy.graphics.transformation import Matrix
         from kivy.properties import StringProperty, NumericProperty, BooleanProperty
         from kivy.metrics import dp
         from kvui import ApAsyncImage, ToolTip
         from .TrackerKivy import SomethingNeatJustToMakePythonHappy
+
+        class BoxStencil(BoxLayout, StencilView):
+            pass
+
+        # ScatterLayout allows for panning with mouse but not scrolling to zoom (only multi-finger pinch)
+        # so we add our own mouse scroll handler
+        class ScrollWheelZoomScatterLayout(ScatterLayout):
+            zoomOutFactor = 1.1
+            zoomInFactor = 1 / zoomOutFactor
+            def on_touch_down(self, touch):
+                if self.parent and not self.parent.collide_point(*touch.pos):
+                    return False
+                # Kind of confusing but mouse scroll is under touch
+                if touch.is_mouse_scrolling:
+                    factor = self.zoomInFactor if touch.button == 'scrollup' else self.zoomOutFactor
+                    # Check if new zoom is within limits so user is less likely to lose the map
+                    if self.scale_min <= self.scale * factor <= self.scale_max:
+                        mat = Matrix().scale(factor, factor, 1)
+                        self.apply_transform(mat, anchor=touch.pos)
+                    return True
+                return super().on_touch_down(touch)
+
+            # We have to overwrite all the touch actions to return False since otherwise it blocks
+            # clicks to other UI elements, even when it's clipped by the stencil view. Not sure
+            # if Kivy has a better way to keep the scatterlayout from escaping its view.
+            def on_touch_move(self, touch):
+                if touch in self._touches:
+                    return super().on_touch_move(touch)
+                return False
+
+            def on_touch_up(self, touch):
+                if touch in self._touches:
+                    return super().on_touch_up(touch)
+                return False
+
+            def recenter_view(self):
+                self.scale = 1.0
+                self.pos = (0, 0)
+                self.transform = Matrix()
 
         class CheckItem(BoxLayout):
             text = StringProperty()


### PR DESCRIPTION
## What is this fixing or adding?

- Basic zoom and pan to map tracker
- Slightly tweaks centering on top map controls to make it look less janky
- Adds a recenter button

## How was this tested?

On the little_witch_nobeta map pack. This only wraps the map view in a kivy scatterlayout component so (hopefully) it shouldn't break anything for other packs.

Also all the UT touchers will be happy to know touch controls also seem to work pretty good for this. (Are there people who actually use touch controls??)

## If this makes graphical changes, please attach screenshots.
<img width="1042" height="781" src="https://github.com/user-attachments/assets/819f7677-6487-4a70-aa0d-7fd4d1f17d32" />

https://github.com/user-attachments/assets/58837014-20e9-4812-a293-a450fe1a2d34

